### PR TITLE
Using stream uploadSequenceToken only if it was defined

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -72,7 +72,7 @@ class CloudWatch extends AbstractProcessingHandler
         // update sequence token
         $this->uploadSequenceToken = $response->get('nextSequenceToken');
     }
-    
+
     private function initialize()
     {
         // fetch existing groups
@@ -120,7 +120,7 @@ class CloudWatch extends AbstractProcessingHandler
         $existingStreamsNames = array_map(function ($stream) {
 
             // set sequence token
-            if ($stream['logStreamName'] === $this->logStreamName) {
+            if ($stream['logStreamName'] === $this->logStreamName && isset($stream['uploadSequenceToken'])) {
                 $this->uploadSequenceToken = $stream['uploadSequenceToken'];
             }
 


### PR DESCRIPTION
Protecting agains "PHP Notice:  Undefined index: uploadSequenceToken" in case one was not defined.
(*) For the record, it seem like this behavior happens only when connecting to an account for the first time.
Still, this should not happen.