### PR TITLE
Prevent empty tags as argument when creating logGroup

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -227,14 +227,14 @@ class CloudWatch extends AbstractProcessingHandler
 
         // create group and set retention policy if not created yet
         if (!in_array($this->group, $existingGroupsNames, true)) {
+            $createLogGroupArguments = ['logGroupName' => $this->group];
+            if(count($this->tags) > 0){
+                $createLogGroupArguments['tags'] = $this->tags;
+            }
+            
             $this
                 ->client
-                ->createLogGroup(
-                    [
-                        'logGroupName' => $this->group,
-                        'tags' => $this->tags
-                    ]
-                );
+                ->createLogGroup($createLogGroupArguments);
             $this
                 ->client
                 ->putRetentionPolicy(

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -89,6 +89,104 @@ class CloudWatchLogsTest extends \PHPUnit_Framework_TestCase
         $reflectionMethod->invoke($handler);
     }
 
+    public function testInitializeWithTags()
+    {
+        $tags = [
+            'applicationName' => 'dummyApplicationName',
+            'applicationEnvironment' => 'dummyApplicationEnvironment'
+        ];
+
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('createLogGroup')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'tags' => $tags
+            ]);
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName,
+                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
+
+        $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, $tags);
+
+        $reflection = new \ReflectionClass($handler);
+        $reflectionMethod = $reflection->getMethod('initialize');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($handler);
+    }
+
+    public function testInitializeWithEmptyTags()
+    {
+        $tags = array();
+
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('createLogGroup')
+            ->with(['logGroupName' => $this->groupName]); //The empty array of tags is not handed over
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName,
+                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
+
+        $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, $tags);
+
+        $reflection = new \ReflectionClass($handler);
+        $reflectionMethod = $reflection->getMethod('initialize');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($handler);
+    }
+
     public function testInitializeWithMissingGroupAndStream()
     {
         $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -104,7 +104,7 @@ class CloudWatchLogsTest extends \PHPUnit_Framework_TestCase
             ->clientMock
             ->expects($this->once())
             ->method('createLogGroup')
-            ->with(['logGroupName' => $this->groupName, 'tags' => []]);
+            ->with(['logGroupName' => $this->groupName]);
 
         $this
             ->clientMock


### PR DESCRIPTION
As reported in https://github.com/maxbanton/cwh/issues/15