### PR TITLE
Implement a clone method to register the handler's shutdown function.

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -112,6 +112,11 @@ class CloudWatch extends AbstractProcessingHandler
         register_shutdown_function([$this, 'close']);
     }
 
+    public function __clone()
+    {
+        register_shutdown_function([$this, 'close']);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This addresses an issue where a cloned handler does not flush its
buffer.