### PR TITLE
Make cwh compatible with Monolog FingersCrossedHandler

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -124,14 +124,8 @@ class CloudWatch extends AbstractProcessingHandler
         $this->tags = $tags;
 
         parent::__construct($level, $bubble);
-        register_shutdown_function([$this, 'close']);
 
         $this->savedTime = new \DateTime;
-    }
-
-    public function __clone()
-    {
-        register_shutdown_function([$this, 'close']);
     }
 
     /**
@@ -342,15 +336,5 @@ class CloudWatch extends AbstractProcessingHandler
     public function close()
     {
         $this->flushBuffer();
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function __destruct()
-    {
-        // suppress the parent behavior since we already have register_shutdown_function()
-        // to call close(), and the reference contained there will prevent this from being
-        // GC'd until the end of the request
     }
 }


### PR DESCRIPTION
Hi @maxbanton,

we'd like to use `cwh` in a combination with `\Monolog\Handler\FingersCrossedHandler` but it seems these two handlers are incompatible.

I tried to describe the problem as much as possible.

Thank you for your time!

## Details

`close` methods of handlers are called in the wrong order:
```
1. Maxbanton\Cwh\Handler\CloudWatch::close // flushes its buffer to AWS service
2. Monolog\Handler\FingersCrossedHandler::close // flushes its buffer to Cloudwatch Handler
3. Maxbanton\Cwh\Handler\CloudWatch::__destruct // does not do anything intentionally
```
resulting in the buffer of `CloudWatchHandler` being filled by `FingersCrossedHandler` after `CloudWatchHandler` pushed data to AWS.

The `close` method of monolog handlers is called in `\Monolog\Handler\AbstractHandler::__destruct` but `close` of Cloudwatch handler is registered by `register_shutdown_function` in `\Maxbanton\Cwh\Handler\CloudWatch::__construct`

Apparently, custom shutdown handlers are called before PHP destructors.

```
class Foo {
    public function __construct() {
        print __METHOD__ . PHP_EOL;
        register_shutdown_function([$this, 'close']);
    }
    public function __destruct() {
        print __METHOD__ . PHP_EOL;
    }
    public function close() {
        print __METHOD__ . PHP_EOL;
    }
}
new Foo();

// results in:

Foo::__construct
Foo::close
Foo::__destruct
```

```
$ php -v

PHP 7.1.14 (cli) (built: Feb  7 2018 18:33:30) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
```

```
$ cat monolog.yaml

monolog:
    handlers:
        cloudwatch_filter:
            type: fingers_crossed
            handler: cloudwatch
            action_level: error
            passthru_level: notice
        cloudwatch:
            type: service
            id: cloudwatch_handler
```

## Suggestion

Comply with a Monolog flow and let `\Monolog\Handler\AbstractHandler::__destruct` call `close` method.