### PR TITLE
Fix: Move build steps to appropriate sections in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,18 @@ cache:
   directories:
   - "$HOME/.composer"
 
-before_script:
+before_install:
   - composer validate
+  
+install:
   - composer install --no-interaction -o --prefer-dist --no-suggest
+  
+before_script:
+  - mkdir -p build/logs
 
 script:
   - php -l src/
   - composer check-syntax
-  - mkdir -p build/logs
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:


### PR DESCRIPTION
This PR

* [x] moves build steps to appropriate sections in `.travis.yml`

💁‍♂️ For reference, see https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle.