### PR TITLE
Enhancement: Configure preferred installation method in composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - composer validate
   
 install:
-  - composer install --no-interaction -o --prefer-dist --no-suggest
+  - composer install --no-interaction -o --no-suggest
   
 before_script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "phpunit/phpunit": "^5.6",
         "squizlabs/php_codesniffer": "2.*"
     },
+    "config": {
+        "preferred-install": "dist"
+    },
     "autoload": {
         "psr-4": {
             "Maxbanton\\Cwh\\": "src"


### PR DESCRIPTION
This PR

* [x] configures the preferred installation method in `composer.json`

💁‍♂️ Then we don't need to specify it when installing dependencies.