### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -32,7 +32,7 @@ class CloudWatchLogsTest extends \PHPUnit_Framework_TestCase
      */
     private $streamName = 'stream';
 
-    public function setUp()
+    protected function setUp()
     {
         $this->clientMock =
             $this


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` from `public` to `protected`

💁‍♂️ This is the visibility as declared on the parent; there's no need to modify it.