### PR TITLE
Enhancement: Use short array syntax

### DIFF
--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -349,17 +349,17 @@ class CloudWatchLogsTest extends \PHPUnit_Framework_TestCase
      * @param array $context
      * @return array
      */
-    private function getRecord($level = Logger::WARNING, $message = 'test', $context = array())
+    private function getRecord($level = Logger::WARNING, $message = 'test', $context = [])
     {
-        return array(
+        return [
             'message' => $message,
             'context' => $context,
             'level' => $level,
             'level_name' => Logger::getLevelName($level),
             'channel' => 'test',
             'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
-            'extra' => array(),
-        );
+            'extra' => [],
+        ];
     }
 
     /**
@@ -367,12 +367,12 @@ class CloudWatchLogsTest extends \PHPUnit_Framework_TestCase
      */
     private function getMultipleRecords()
     {
-        return array(
+        return [
             $this->getRecord(Logger::DEBUG, 'debug message 1'),
             $this->getRecord(Logger::DEBUG, 'debug message 2'),
             $this->getRecord(Logger::INFO, 'information'),
             $this->getRecord(Logger::WARNING, 'warning'),
             $this->getRecord(Logger::ERROR, 'error'),
-        );
+        ];
     }
 }


### PR DESCRIPTION
This PR

* [x] uses short array syntax

💁‍♂️ Since we require PHP5.6, this should be good. See [`composer.json`](https://github.com/maxbanton/cwh/blob/86b212a4ff1acb35653f4d5ac6299050b9d333b7/composer.json#L20).