### PR TITLE
Fix: Class name does not match file name

### DIFF
--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -9,7 +9,7 @@ use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger;
 
-class CloudWatchLogsTest extends \PHPUnit_Framework_TestCase
+class CloudWatchTest extends \PHPUnit_Framework_TestCase
 {
 
     /**


### PR DESCRIPTION
This PR

* [x] renames a test class name so it matches both the name of the containing file as well as maps to the system under test