### PR TITLE
Fix: Extend from namespaced test case

### DIFF
--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -8,8 +8,9 @@ use Aws\Result;
 use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 
-class CloudWatchTest extends \PHPUnit_Framework_TestCase
+class CloudWatchTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
This PR

* [x] extends from the namespaced `PHPUnit\Framework\TestCase`

💁‍♂️ Since we require `phpunit/phpunit:^5.6.`, this should be good to go.
