### PR TITLE
Fix: Add missing parameter type to docblock

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -188,7 +188,7 @@ class CloudWatch extends AbstractProcessingHandler
     /**
      * http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
      *
-     * @param $record
+     * @param array $record
      * @return int
      */
     private function getMessageSize($record)


### PR DESCRIPTION
This PR

* [x] adds a missing parameter type to a docblock

💁‍♂️ Running

```
$ phpstan analyse --level=max src
```

on current `master` yields

```
1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------------------------------------------------------
  Line   src/Handler/CloudWatch.php
 ------ --------------------------------------------------------------------------------------------------------------------
  194    PHPDoc tag @param has invalid value ($record): Unexpected token "$record", expected TOKEN_IDENTIFIER at offset 122
 ------ --------------------------------------------------------------------------------------------------------------------


 [ERROR] Found 1 error
```