### PR TITLE
Enhancement: Reference phpunit.xsd in phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,8 +9,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Handler Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` (as installed with `composer`) in `phpunit.xml`
* [x] removes an unsupported configuration option