### PR TITLE
 Add support for indefinite retention

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -272,14 +272,17 @@ class CloudWatch extends AbstractProcessingHandler
             $this
                 ->client
                 ->createLogGroup($createLogGroupArguments);
-            $this
-                ->client
-                ->putRetentionPolicy(
-                    [
-                        'logGroupName' => $this->group,
-                        'retentionInDays' => $this->retention,
-                    ]
-                );
+                
+            if ($this->retention != null) {
+                $this
+	                ->client
+	                ->putRetentionPolicy(
+	                    [
+	                        'logGroupName' => $this->group,
+	                        'retentionInDays' => $this->retention,
+	                    ]
+	                );
+            }
         }
 
         // fetch existing streams

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -273,7 +273,7 @@ class CloudWatch extends AbstractProcessingHandler
                 ->client
                 ->createLogGroup($createLogGroupArguments);
                 
-            if ($this->retention != null) {
+            if ($this->retention !== null) {
                 $this
 	                ->client
 	                ->putRetentionPolicy(

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -275,13 +275,13 @@ class CloudWatch extends AbstractProcessingHandler
                 
             if ($this->retention !== null) {
                 $this
-	                ->client
-	                ->putRetentionPolicy(
-	                    [
-	                        'logGroupName' => $this->group,
-	                        'retentionInDays' => $this->retention,
-	                    ]
-	                );
+                    ->client
+                    ->putRetentionPolicy(
+                        [
+                            'logGroupName' => $this->group,
+                            'retentionInDays' => $this->retention,
+                        ]
+                    );
             }
         }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allows for you to pass null into the `$retention` parameter. This will not set a retention policy so your logs can be retained indefinitely.

* **What is the current behavior?** (You can also link to an open issue here)
If you pass null into the `$retention` parameter the log group is created, but the putRetentionPolicy call fails because `retentionInDays` must not be null according to the [documentation](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html). As a result the log stream is not created until initialize() is called a second time.

* **What is the new behavior (if this is a feature change)?**
Optionally allows for you to have never expiring logs.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
None.