### PR TITLE
Refresh with fresh sequence token

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -248,7 +248,8 @@ class CloudWatch extends AbstractProcessingHandler
      *
      * @param array $entries
      *
-     * @throws \Aws\CloudWatchLogs\Exception\CloudWatchLogsException Thrown by putLogEvents for example in case of an invalid sequence token
+     * @throws \Aws\CloudWatchLogs\Exception\CloudWatchLogsException Thrown by putLogEvents for example in case of an
+     *                                                               invalid sequence token
      */
     private function send(array $entries)
     {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

An exception about an invalid CloudWatch log stream sequence token appears while running a long script in Docker. I suspect another process creates a new sequence token and invalidates the one used by a Docker instance. This will probably happen when running a cluster of few web instances trying to write logs in a same time too.

Exception:
```
23:03:37 ERROR [console] Error thrown while running command "*****". 
Message: "Error executing "PutLogEvents" on "https://logs.eu-central-1.amazonaws.com"; 
AWS HTTP error: Client error: `POST https://logs.eu-central-1.amazonaws.com` resulted in a `400 Bad Request` response:
{
  "__type": "InvalidSequenceTokenException",
  "expectedSequenceToken": "49588220171152916907562770980898637167375952589803759 (truncated...) InvalidSequenceTokenException (client): The given sequenceToken is invalid. The next expected sequenceToken is: 49588220171152916907562770980898637167375952589803759074"
}
{
  "__type": "InvalidSequenceTokenException",
  "expectedSequenceToken": "49588220171152916907562770980898637167375952589803759074",
  "message": "The given sequenceToken is invalid. The next expected sequenceToken is: 49588220171152916907562770980898637167375952589803759074"
}
{
    "exception" => Aws\CloudWatchLogs\Exception\CloudWatchLogsException {},
    "command" => "***",
    "message" => "Error executing \"PutLogEvents\" on \"https://logs.eu-central-1.amazonaws.com\"; 
    AWS HTTP error: Client error: `POST https://logs.eu-central-1.amazonaws.com` resulted in a `400 Bad Request` response:
    {
        "__type": "InvalidSequenceTokenException",
        "expectedSequenceToken":
        49588220171152916907562770980898637167375952589803759 (truncated...)
        InvalidSequenceTokenException (client): The given sequenceToken is invalid. The next expected sequenceToken is: 49588220171152916907562770980898637167375952589803759074
    }
}
```

* **What is the new behavior (if this is a feature change)?**

Handler retries to send entries to CloudWatch once an exception `\Aws\CloudWatchLogs\Exception\CloudWatchLogsException` is thrown by a client. It gets a fresh sequence token from CloudWatch log stream before retry. 
It does not check the exact type of an exception simply because I did not notice another exception.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes

* **Other information**:

Hi Max, 
we still use your library in our main project and we don't notice any troubles when running in for user requests 👍
I hope you will find a time to review and test this PR so we can upgrage to a new version.
