### PR TITLE
Suggest to assign the JsonFormatter in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ $handler = new CloudWatch($client, $groupName, $streamName, $retentionDays, 1000
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Logger;
+use Monolog\Formatter\JsonFormatter;
 
 $sdkParams = [
     'region' => 'eu-west-1',
@@ -87,6 +88,9 @@ $retentionDays = 30;
 
 // Instantiate handler (tags are optional)
 $handler = new CloudWatch($client, $groupName, $streamName, $retentionDays, 10000, ['my-awesome-tag' => 'tag-value']);
+
+// Optionally set the JsonFormatter to be able to access your log messages in a structured way
+$handler->setFormatter(new JsonFormatter());
 
 // Create a log channel
 $log = new Logger('name');


### PR DESCRIPTION
Also discussed (a bit) here: https://github.com/maxbanton/cwh/issues/27

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update

* **What is the current behavior?** (You can also link to an open issue here)
No mention of possibility to use the JsonFormatter

* **What is the new behavior (if this is a feature change)?**
Encourage usage of the JsonFormater

* **Does this PR introduce a breaking change?** 
No

* **Other information**:
Using the JsonFormatter allows the user to use CloudWatch Log Insights as well to "query" the logs

https://aws.amazon.com/blogs/aws/new-amazon-cloudwatch-logs-insights-fast-interactive-log-analytics/