### PR TITLE
Do not overshadow errors thrown by DescribeLogGroups with those from DescribeLogStreams

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -168,6 +168,10 @@ class CloudWatch extends AbstractProcessingHandler
     private function flushBuffer()
     {
         if (!empty($this->buffer)) {
+            if (false === $this->initialized) {
+                $this->initialize();
+            }
+
             // send items, retry once with a fresh sequence token
             try {
                 $this->send($this->buffer);
@@ -254,10 +258,6 @@ class CloudWatch extends AbstractProcessingHandler
      */
     private function send(array $entries)
     {
-        if (false === $this->initialized) {
-            $this->initialize();
-        }
-
         $data = [
             'logGroupName' => $this->group,
             'logStreamName' => $this->stream,
@@ -317,8 +317,6 @@ class CloudWatch extends AbstractProcessingHandler
         }
 
         $this->refreshSequenceToken();
-
-        $this->initialized = true;
     }
 
     private function refreshSequenceToken()


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Bug fix

* **What is the current behavior?**
If DescribeLogGroups throws an error (e.g. AccessDeniedException), the retry logic
will still call DescribeLogStreams, which will also fail, either with
AccessDeniedException, or, more confusingly, with "The specified log group
does not exist." if the log group has never been created.

* **What is the new behavior (if this is a feature change)?**
This change makes sure that the original error is thrown.

* **Does this PR introduce a breaking change?**
Nope.
