### PR TITLE
Sort log entries chronologically before calling PutLogEvents.

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -258,6 +258,17 @@ class CloudWatch extends AbstractProcessingHandler
      */
     private function send(array $entries)
     {
+        // AWS expects to receive entries in chronological order...
+        usort($entries, static function (array $a, array $b) {
+            if ($a['timestamp'] < $b['timestamp']) {
+                return -1;
+            } elseif ($a['timestamp'] > $b['timestamp']) {
+                return 1;
+            }
+
+            return 0;
+        });
+
         $data = [
             'logGroupName' => $this->group,
             'logStreamName' => $this->stream,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?**

See issues #32 and #69.

* **What is the new behavior (if this is a feature change)?**

Chronological order of log entries is ensured before submission.

* **Does this PR introduce a breaking change?**

No.

* **Other information**:

The comparison logic is the fastest one still supported on PHP 5.6. The spaceship operator seems to be a little bit faster, but not available in PHP 5.