### PR TITLE
Enhancement: Use AWS suggested LineFormatter attributes

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -366,7 +366,7 @@ class CloudWatch extends AbstractProcessingHandler
      */
     protected function getDefaultFormatter()
     {
-        return new LineFormatter("%channel%: %level_name%: %message% %context% %extra%",null,false,true);
+        return new LineFormatter("%channel%: %level_name%: %message% %context% %extra%", null, false, true);
     }
 
     /**

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -366,7 +366,7 @@ class CloudWatch extends AbstractProcessingHandler
      */
     protected function getDefaultFormatter()
     {
-        return new LineFormatter("%level_name%: %message% %context% %extra%\n");
+        return new LineFormatter("%channel%: %level_name%: %message% %context% %extra%",null,false,true);
     }
 
     /**

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -297,7 +297,7 @@ class CloudWatchTest extends TestCase
 
         $formatter = $handler->getFormatter();
 
-        $expected = new LineFormatter("%channel%: %level_name%: %message% %context% %extra%",null,false,true);
+        $expected = new LineFormatter("%channel%: %level_name%: %message% %context% %extra%", null, false, true);
 
         $this->assertEquals($expected, $formatter);
     }

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -297,7 +297,7 @@ class CloudWatchTest extends TestCase
 
         $formatter = $handler->getFormatter();
 
-        $expected = new LineFormatter("%level_name%: %message% %context% %extra%\n");
+        $expected = new LineFormatter("%channel%: %level_name%: %message% %context% %extra%",null,false,true);
 
         $this->assertEquals($expected, $formatter);
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Create LineFormatter with the $ignoreEmptyContextAndExtra set to false

* **What is the new behavior (if this is a feature change)?**
Create LineFormatter with the $ignoreEmptyContextAndExtra set to true 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
This fix losing [stacktrace] data.
This fix showing [] [] in cloudwatch console.
The attributes passed to LineFormatter are being suggested by AWS documentation. Please refer to https://aws.amazon.com/blogs/developer/php-application-logging-with-amazon-cloudwatch-logs-and-monolog/