### PR TITLE
Added option to disable creating the log group

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ if you prefer to use a separate programmatic IAM user (recommended) or want to d
 1. `DescribeLogStreams` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html)
 1. `DescribeLogGroups` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html)
 
+When setting the `$createGroup` argument to `false`, permissions `DescribeLogGroups` and `CreateLogGroup` can be omitted
+
 ## AWS IAM Policy full json example
 ```json
 {
@@ -154,8 +156,6 @@ if you prefer to use a separate programmatic IAM user (recommended) or want to d
     ]
 }
 ```
-
-When setting the `$createGroup` argument to `false`, permissions `logs:DescribeLogGroups` and `logs:CreateLogGroup` can be omitted
 
 ## Issues
 Feel free to [report any issues](https://github.com/maxbanton/cwh/issues/new)

--- a/README.md
+++ b/README.md
@@ -89,9 +89,6 @@ $retentionDays = 30;
 // Instantiate handler (tags are optional)
 $handler = new CloudWatch($client, $groupName, $streamName, $retentionDays, 10000, ['my-awesome-tag' => 'tag-value']);
 
-// Optionally disable creating the log group, if it has been created manually
-$handler->disableCreateGroup();
-
 // Optionally set the JsonFormatter to be able to access your log messages in a structured way
 $handler->setFormatter(new JsonFormatter());
 
@@ -158,7 +155,7 @@ if you prefer to use a separate programmatic IAM user (recommended) or want to d
 }
 ```
 
-When using the `disableCreateGroup` option, permissions `logs:DescribeLogGroups` and `logs:CreateLogGroup` can be omitted
+When setting the `$createGroup` argument to `false`, permissions `logs:DescribeLogGroups` and `logs:CreateLogGroup` can be omitted
 
 ## Issues
 Feel free to [report any issues](https://github.com/maxbanton/cwh/issues/new)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ $retentionDays = 30;
 // Instantiate handler (tags are optional)
 $handler = new CloudWatch($client, $groupName, $streamName, $retentionDays, 10000, ['my-awesome-tag' => 'tag-value']);
 
+// Optionally disable creating the log group, if it has been created manually
+$handler->disableCreateGroup();
+
 // Optionally set the JsonFormatter to be able to access your log messages in a structured way
 $handler->setFormatter(new JsonFormatter());
 
@@ -154,6 +157,8 @@ if you prefer to use a separate programmatic IAM user (recommended) or want to d
     ]
 }
 ```
+
+When using the `disableCreateGroup` option, permissions `logs:DescribeLogGroups` and `logs:CreateLogGroup` can be omitted
 
 ## Issues
 Feel free to [report any issues](https://github.com/maxbanton/cwh/issues/new)

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -69,7 +69,7 @@ class CloudWatch extends AbstractProcessingHandler
     /**
      * @var bool
      */
-    private $createGroup = true;
+    private $createGroup;
 
     /**
      * Data amount limit (http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
@@ -113,6 +113,7 @@ class CloudWatch extends AbstractProcessingHandler
      * @param array $tags
      * @param int $level
      * @param bool $bubble
+     * @param bool $createGroup
      */
     public function __construct(
         CloudWatchLogsClient $client,
@@ -122,7 +123,8 @@ class CloudWatch extends AbstractProcessingHandler
         $batchSize = 10000,
         array $tags = [],
         $level = Logger::DEBUG,
-        $bubble = true
+        $bubble = true,
+        $createGroup = true
     ) {
         if ($batchSize > 10000) {
             throw new \InvalidArgumentException('Batch size can not be greater than 10000');
@@ -134,15 +136,11 @@ class CloudWatch extends AbstractProcessingHandler
         $this->retention = $retention;
         $this->batchSize = $batchSize;
         $this->tags = $tags;
+        $this->createGroup = $createGroup;
 
         parent::__construct($level, $bubble);
 
         $this->savedTime = new \DateTime;
-    }
-
-    public function disableCreateGroup()
-    {
-        $this->createGroup = false;
     }
 
     /**

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -67,6 +67,11 @@ class CloudWatch extends AbstractProcessingHandler
     private $tags = [];
 
     /**
+     * @var bool
+     */
+    private $createGroup = true;
+
+    /**
      * Data amount limit (http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
      *
      * @var int
@@ -133,6 +138,11 @@ class CloudWatch extends AbstractProcessingHandler
         parent::__construct($level, $bubble);
 
         $this->savedTime = new \DateTime;
+    }
+
+    public function disableCreateGroup()
+    {
+        $this->createGroup = false;
     }
 
     /**
@@ -286,7 +296,7 @@ class CloudWatch extends AbstractProcessingHandler
         $this->sequenceToken = $response->get('nextSequenceToken');
     }
 
-    private function initialize()
+    private function initializeGroup()
     {
         // fetch existing groups
         $existingGroups =
@@ -325,6 +335,13 @@ class CloudWatch extends AbstractProcessingHandler
                         ]
                     );
             }
+        }
+    }
+
+    private function initialize()
+    {
+        if ($this->createGroup) {
+            $this->initializeGroup();
         }
 
         $this->refreshSequenceToken();

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -84,8 +84,7 @@ class CloudWatchTest extends TestCase
             ])
             ->willReturn($logStreamResult);
 
-        $handler = $this->getCUT();
-        $handler->disableCreateGroup();
+        $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, [], Logger::DEBUG, true, false);
 
         $reflection = new \ReflectionClass($handler);
         $reflectionMethod = $reflection->getMethod('initialize');

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -53,6 +53,46 @@ class CloudWatchTest extends TestCase
                 ->getMock();
     }
 
+    public function testInitializeWithCreateGroupDisabled()
+    {
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('describeLogGroups');
+
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('createLogGroup');
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName,
+                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
+
+        $handler = $this->getCUT();
+        $handler->disableCreateGroup();
+
+        $reflection = new \ReflectionClass($handler);
+        $reflectionMethod = $reflection->getMethod('initialize');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($handler);
+    }
+
     public function testInitializeWithExistingLogGroup()
     {
         $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
The handler checks for existence of the given log group, if it doesn't exist, it created the log group

* **What is the new behavior (if this is a feature change)?**
By enabling the option, the handler doesn't check for the group's existence and goes on with initializing the stream.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, existing behavior remains unchanged. 
User has to explicitly trigger the option

* **Other information**:
This change was made in an effort to reduce the security boundaries of the application (I create the log group beforehand and don't need the app to have logs:DescribeLogGroups and logs:CreateLogGroup permissions. Also, not checking if the group exists improves the performance by removing the HTTP call.

Please let me know what you think about it. 

Alternatively, I propose to make the initialize and refreshSequenceToken methods protected, because currently there's no way to achieve my change by extending the class, so copy-pasting the whole class is the only solution. 