### PR TITLE
Updated the permission resources in the readme for DescribeLogGroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,15 @@ When setting the `$createGroup` argument to `false`, permissions `DescribeLogGro
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": "logs:CreateLogGroup",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DescribeLogGroups"
+            ],
             "Resource": "*"
         },
         {
             "Effect": "Allow",
             "Action": [
-                "logs:DescribeLogGroups",
                 "logs:CreateLogStream",
                 "logs:DescribeLogStreams",
                 "logs:PutRetentionPolicy"


### PR DESCRIPTION
Permissions for listing the existing log groups need to be able to list all the log groups on the account, to allow it to filter the groups based on the log group name.  If you don't, you end up not getting a log stream or any log data.

* **What kind of change does this PR introduce?** 
Docs update

* **What is the current behavior?**
With the default permissions, you can't list the log groups, resulting in you not getting any logs into CloudWatch Logs.

* **What is the new behavior (if this is a feature change)?**
N/A

* **Does this PR introduce a breaking change?**
No. 
`
* **Other information**:


From my testing using the AWS CLI, I set up a user with the following permissions:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": "logs:DescribeLogGroups",
            "Resource": "arn:aws:logs:eu-west-1:ACCOUNT_ID:log-group:test-log-group:*",
            "Effect": "Allow"
        }
    ]
}
```

I then create a log group called test-log-group and ran: 
`aws logs describe-log-groups --log-group-name-prefix="test-log-group"`

Which gave the result:
```
An error occurred (AccessDeniedException) when calling the DescribeLogGroups operation: User: arn:aws:iam::ACCOUNT_ID:user/test-user is not authorized to perform: logs:DescribeLogGroups on resource: arn:aws:logs:eu-west-1:ACCOUNT_ID:log-group::log-stream:
```

Changing the resource on the permissions to * did then work.  The same behaviour exists when using the PHP SDK.