### PR TITLE
Make handler flush on reset

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -405,4 +405,14 @@ class CloudWatch extends AbstractProcessingHandler
     {
         $this->flushBuffer();
     }
+    
+    /**
+     * Flush buffer on logger reset
+     * @inheritDoc
+     */
+    public function reset(): void
+    {
+        $this->flushBuffer();
+        parent::reset();
+    }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
`CloudWatch` implements `ResettableInterface` (via `AbstractHandler`), but does nothing on resetting. That means that long running processes like the message consumer don't flush logs between handling messages.

* **What is the current behavior?** (You can also link to an open issue here)
Calling `reset()` on logger doesn't do anything

* **What is the new behavior (if this is a feature change)?**
Calling `reset()` on logger flushes messages

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
