### PR TITLE
Making the $retention param type nullable since it can be null already

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -38,7 +38,7 @@ class CloudWatch extends AbstractProcessingHandler
     private $stream;
 
     /**
-     * @var integer
+     * @var int|null
      */
     private $retention;
 
@@ -109,7 +109,7 @@ class CloudWatch extends AbstractProcessingHandler
      *  The ':' (colon) and '*' (asterisk) characters are not allowed.
      * @param string $stream
      *
-     * @param int $retention
+     * @param int|null $retention
      * @param int $batchSize
      * @param array $tags
      * @param int $level


### PR DESCRIPTION
When using this component with static analyzers (such as phpstan) we are not able to pass `null` as retention because the parameter is marked as int. This fixes it.