### PR TITLE
Remove sequence token for PutLogEvents

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -133,15 +133,15 @@ class CloudWatch extends AbstractProcessingHandler
      */
     public function __construct(
         CloudWatchLogsClient $client,
-                             $group,
-                             $stream,
-                             $retention = 14,
-                             $batchSize = 10000,
+        $group,
+        $stream,
+        $retention = 14,
+        $batchSize = 10000,
         array $tags = [],
-                             $level = Logger::DEBUG,
-                             $bubble = true,
-                             $createGroup = true,
-                             $createStream = true,
+        $level = Logger::DEBUG,
+        $bubble = true,
+        $createGroup = true,
+        $createStream = true,
     ) {
         if ($batchSize > 10000) {
             throw new \InvalidArgumentException('Batch size can not be greater than 10000');


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
On January 4, 2023, Amazon announced that the [sequence token is no longer required for `PutLogEvents`](https://aws.amazon.com/about-aws/whats-new/2023/01/amazon-cloudwatch-logs-log-stream-transaction-quota-sequencetoken-requirement/). This PR updates the library to reflect this new change and also adds functionality to emulate `createGroup` for log streams.

* **What is the current behavior?** (You can also link to an open issue here)
The `refreshSequenceToken()` function gets called somewhat regularly throughout the code.

* **What is the new behavior (if this is a feature change)?**
No more `refreshSequenceToken()` or associated calls!

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Based upon my initial testing, this does **not** cause a breaking change -- I was able to slide this in seamlessly without any issues in my environment. The AWS announcement notes that this change is available in all commercial regions which, I assume, means that ex. GovCloud doesn't have support for this? But the [API Documentation](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html) doesn't reflect this limitation... 🤷 
This _does_ open up the possibility for users to leverage the new `createStream` constructor option to skip the `describeLogGroups` calls (which can cause issues similar to #113 and, frankly, is the reason I'm doing this in the first place).

* **Other information**:
This is also addressed in request #114.
