### PR TITLE
Cast timestamp to integer for earliestTimestamp

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -113,7 +113,7 @@ class CloudWatch extends AbstractProcessingHandler
         $timestamp = $record['timestamp'];
 
         if (!$this->earliestTimestamp || $timestamp < $this->earliestTimestamp) {
-            $this->earliestTimestamp = $timestamp;
+            $this->earliestTimestamp = (int)$timestamp;
         }
 
         $this->buffer[] = $record;


### PR DESCRIPTION
Removed php warning 

`implicit conversion from float to int loses precision maxbanton/cwh/src/Handler/CloudWatch.php on line 116`