### PR TITLE
v2.1.0 — AWS API alignment, Docker dev env, contributor PRs

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 permissions:
   contents: read
@@ -12,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4', '8.5']
+        php: ["8.2", "8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.phpunit.result.cache
 /composer.lock
 /build/
+/tests/smoke/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.0] - 2026-04-26
+
+### Added
+
+- Public `flush()` method for long-lived workers (Laravel queues, Symfony messenger, PHP-FPM with persistent state). The handler's `reset()` is also overridden to flush, integrating with Symfony `ResettableInterface` and Laravel Octane's `FlushMonologState`. (#95, thanks @DrLuke for #102)
+- README section documenting ECS / EC2 IAM Task Role credentials with `CredentialProvider::memoize()`. (#103)
+- Docker-based local dev environment (`make build`, `make test`, `make matrix`) running against PHP 8.2 / 8.3 / 8.4 / 8.5.
+- CI runs entirely in Docker containers; only `actions/checkout` and `actions/upload-artifact` (both official) are used.
+- `.gitattributes` excludes dev files from the Composer dist tarball; `composer require maxbanton/cwh` now ships only `LICENSE`, `README.md`, `composer.json`, and `src/Handler/CloudWatch.php` (~57% smaller).
+
+### Changed
+
+- `EVENT_SIZE_LIMIT` raised from 256 KB to **1 MB (1,048,550 bytes)** to match the current AWS PutLogEvents quota. Messages between 256 KB and 1 MB are now shipped as a single CloudWatch event instead of split. (#101)
+- Log group / stream initialization now uses idempotent create-and-swallow-`ResourceAlreadyExistsException` pattern instead of pre-flight `describeLogGroups` / `describeLogStreams`. Removes 2 AWS API calls per process startup and shrinks the required IAM permissions. (#86, #120)
+- `$retention` constructor parameter is now typed as `?int`. (thanks @vinicius-venngage for #105)
+
+### Removed
+
+- `RPS_LIMIT` self-throttle (5 RPS). The library no longer sleeps to artificially cap PutLogEvents calls — the AWS quota is 5,000 TPS per account/region (1000× higher), and the AWS SDK's retry middleware handles real throttling automatically. (#111, #114)
+- `sequenceToken` tracking. AWS deprecated this parameter in August 2023 — `PutLogEvents` ignores it server-side and never throws `InvalidSequenceTokenException` or `DataAlreadyAcceptedException` anymore. (thanks @a10waveracer for #115)
+- The retry-on-`CloudWatchLogsException` loop in `flushBuffer()` (it existed solely to refresh the sequence token, which no longer matters).
+- Required IAM permissions `logs:DescribeLogStreams` and `logs:DescribeLogGroups`. Existing policies that still grant these permissions remain compatible — extra permissions are harmless. (#114)
+
+### Fixed
+
+- `checkThrottle()` had a latent bug — `$current->diff($savedTime)->s` reads only the seconds component of a DateInterval, misbehaving across minute boundaries. Fixed by removing the method entirely (see "Removed" above).
+
+### Compatibility
+
+- **No breaking public API changes.** Adds public `flush()` and overrides `reset()` to flush. Existing constructor and method signatures are unchanged; existing `^2.0` pins continue to work without modification.
+- Minimum PHP / Monolog versions unchanged (`^7.2 || ^8` / `monolog/monolog: ^2.0`). CI tests PHP 8.2 – 8.5; no code paths require newer PHP.
+
+[Unreleased]: https://github.com/maxbanton/cwh/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/maxbanton/cwh/compare/v2.0.4...v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `EVENT_SIZE_LIMIT` raised from 256 KB to **1 MB (1,048,550 bytes)** to match the current AWS PutLogEvents quota. Messages between 256 KB and 1 MB are now shipped as a single CloudWatch event instead of split. (#101)
-- Log group / stream initialization now uses idempotent create-and-swallow-`ResourceAlreadyExistsException` pattern instead of pre-flight `describeLogGroups` / `describeLogStreams`. Removes 2 AWS API calls per process startup and shrinks the required IAM permissions. (#86, #120)
-- `$retention` constructor parameter is now typed as `?int`. (thanks @vinicius-venngage for #105)
 
 ### Removed
 
 - `RPS_LIMIT` self-throttle (5 RPS). The library no longer sleeps to artificially cap PutLogEvents calls — the AWS quota is 5,000 TPS per account/region (1000× higher), and the AWS SDK's retry middleware handles real throttling automatically. (#111, #114)
 - `sequenceToken` tracking. AWS deprecated this parameter in August 2023 — `PutLogEvents` ignores it server-side and never throws `InvalidSequenceTokenException` or `DataAlreadyAcceptedException` anymore. (thanks @a10waveracer for #115)
 - The retry-on-`CloudWatchLogsException` loop in `flushBuffer()` (it existed solely to refresh the sequence token, which no longer matters).
-- Required IAM permissions `logs:DescribeLogStreams` and `logs:DescribeLogGroups`. Existing policies that still grant these permissions remain compatible — extra permissions are harmless. (#114)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ build-svc:
 	$(COMPOSE) build $(SERVICE)
 
 install:
-	$(DC) composer install
+	@rm -f composer.lock
+	$(DC) composer update --no-progress --prefer-dist
 
 update:
 	$(DC) composer update

--- a/README.md
+++ b/README.md
@@ -84,6 +84,27 @@ $log->warning('Bar');
 $log->error('Baz');
 ```
 
+## Using IAM Task Roles on ECS / EC2
+
+When running on ECS or EC2, prefer the task/instance IAM role over hard-coded credentials. Wrap the credential provider in `memoize()` so long-running workers don't hit metadata-endpoint timeouts:
+
+```php
+<?php
+
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Aws\Credentials\CredentialProvider;
+
+$provider = CredentialProvider::memoize(
+    CredentialProvider::ecsCredentials()        // or ::instanceProfile() on EC2
+);
+
+$client = new CloudWatchLogsClient([
+    'region'      => 'eu-west-1',
+    'version'     => 'latest',
+    'credentials' => $provider,
+]);
+```
+
 ## Frameworks integration
  - [Silex](http://silex.sensiolabs.org/doc/master/providers/monolog.html#customization)
  - [Symfony](http://symfony.com/doc/current/logging.html) ([Example](https://github.com/maxbanton/cwh/issues/10#issuecomment-296173601))
@@ -94,14 +115,12 @@ $log->error('Baz');
  
 # AWS IAM needed permissions
 if you prefer to use a separate programmatic IAM user (recommended) or want to define a policy, make sure following permissions are included:
-1. `CreateLogGroup` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html)
 1. `CreateLogStream` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html)
 1. `PutLogEvents` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
-1. `PutRetentionPolicy` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html)
-1. `DescribeLogStreams` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html)
-1. `DescribeLogGroups` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html)
+1. `CreateLogGroup` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html) — only when `$createGroup` is true (default)
+1. `PutRetentionPolicy` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html) — only when `$retention` is not null
 
-When setting the `$createGroup` argument to `false`, permissions `DescribeLogGroups` and `CreateLogGroup` can be omitted
+Existing policies that grant `DescribeLogGroups` / `DescribeLogStreams` remain compatible — extra permissions are harmless. The library no longer relies on them since v2.1.
 
 ## AWS IAM Policy full json example
 ```json
@@ -111,8 +130,7 @@ When setting the `$createGroup` argument to `false`, permissions `DescribeLogGro
         {
             "Effect": "Allow",
             "Action": [
-                "logs:CreateLogGroup",
-                "logs:DescribeLogGroups"
+                "logs:CreateLogGroup"
             ],
             "Resource": "*"
         },
@@ -120,7 +138,6 @@ When setting the `$createGroup` argument to `false`, permissions `DescribeLogGro
             "Effect": "Allow",
             "Action": [
                 "logs:CreateLogStream",
-                "logs:DescribeLogStreams",
                 "logs:PutRetentionPolicy"
             ],
             "Resource": "{LOG_GROUP_ARN}"

--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ $client = new CloudWatchLogsClient([
  
 # AWS IAM needed permissions
 if you prefer to use a separate programmatic IAM user (recommended) or want to define a policy, make sure following permissions are included:
+1. `CreateLogGroup` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html)
 1. `CreateLogStream` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html)
 1. `PutLogEvents` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
-1. `CreateLogGroup` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html) — only when `$createGroup` is true (default)
-1. `PutRetentionPolicy` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html) — only when `$retention` is not null
+1. `PutRetentionPolicy` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html)
+1. `DescribeLogStreams` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html)
+1. `DescribeLogGroups` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html)
 
-Existing policies that grant `DescribeLogGroups` / `DescribeLogStreams` remain compatible — extra permissions are harmless. The library no longer relies on them since v2.1.
+When setting the `$createGroup` argument to `false`, permissions `DescribeLogGroups` and `CreateLogGroup` can be omitted
 
 ## AWS IAM Policy full json example
 ```json
@@ -130,7 +132,8 @@ Existing policies that grant `DescribeLogGroups` / `DescribeLogStreams` remain c
         {
             "Effect": "Allow",
             "Action": [
-                "logs:CreateLogGroup"
+                "logs:CreateLogGroup",
+                "logs:DescribeLogGroups"
             ],
             "Resource": "*"
         },
@@ -138,6 +141,7 @@ Existing policies that grant `DescribeLogGroups` / `DescribeLogStreams` remain c
             "Effect": "Allow",
             "Action": [
                 "logs:CreateLogStream",
+                "logs:DescribeLogStreams",
                 "logs:PutRetentionPolicy"
             ],
             "Resource": "{LOG_GROUP_ARN}"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,7 @@
   </coverage>
   <testsuites>
     <testsuite name="Handler Test Suite">
-      <directory suffix=".php">./tests/</directory>
+      <directory suffix="Test.php">./tests/</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -55,11 +55,6 @@ class CloudWatch extends AbstractProcessingHandler
     private $initialized = false;
 
     /**
-     * @var string
-     */
-    private $sequenceToken;
-
-    /**
      * @var int
      */
     private $batchSize;
@@ -201,13 +196,7 @@ class CloudWatch extends AbstractProcessingHandler
                 $this->initialize();
             }
 
-            // send items, retry once with a fresh sequence token
-            try {
-                $this->send($this->buffer);
-            } catch (\Aws\CloudWatchLogs\Exception\CloudWatchLogsException $e) {
-                $this->refreshSequenceToken();
-                $this->send($this->buffer);
-            }
+            $this->send($this->buffer);
 
             // clear buffer
             $this->buffer = [];
@@ -331,15 +320,9 @@ class CloudWatch extends AbstractProcessingHandler
             'logEvents' => $entries
         ];
 
-        if (!empty($this->sequenceToken)) {
-            $data['sequenceToken'] = $this->sequenceToken;
-        }
-
         $this->checkThrottle();
 
-        $response = $this->client->putLogEvents($data);
-
-        $this->sequenceToken = $response->get('nextSequenceToken');
+        $this->client->putLogEvents($data);
     }
 
     private function initializeGroup(): void
@@ -409,12 +392,6 @@ class CloudWatch extends AbstractProcessingHandler
         // extract existing streams names
         $existingStreamsNames = array_map(
             function ($stream) {
-
-                // set sequence token
-                if ($stream['logStreamName'] === $this->stream && isset($stream['uploadSequenceToken'])) {
-                    $this->sequenceToken = $stream['uploadSequenceToken'];
-                }
-
                 return $stream['logStreamName'];
             },
             $existingStreams

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -327,43 +327,33 @@ class CloudWatch extends AbstractProcessingHandler
 
     private function initializeGroup(): void
     {
-        // fetch existing groups
-        $existingGroups =
+        $createLogGroupArguments = ['logGroupName' => $this->group];
+
+        if (!empty($this->tags)) {
+            $createLogGroupArguments['tags'] = $this->tags;
+        }
+
+        $created = false;
+        try {
+            $this->client->createLogGroup($createLogGroupArguments);
+            $created = true;
+        } catch (\Aws\CloudWatchLogs\Exception\CloudWatchLogsException $e) {
+            if ($e->getAwsErrorCode() !== 'ResourceAlreadyExistsException') {
+                throw $e;
+            }
+        }
+
+        // Only set retention on freshly-created groups. Externally-managed retention
+        // (Terraform, manual, infra-as-code) must not be silently overwritten on each init.
+        if ($created && $this->retention !== null) {
             $this
                 ->client
-                ->describeLogGroups(['logGroupNamePrefix' => $this->group])
-                ->get('logGroups');
-
-        // extract existing groups names
-        $existingGroupsNames = array_map(
-            function ($group) {
-                return $group['logGroupName'];
-            },
-            $existingGroups
-        );
-
-        // create group and set retention policy if not created yet
-        if (!in_array($this->group, $existingGroupsNames, true)) {
-            $createLogGroupArguments = ['logGroupName' => $this->group];
-
-            if (!empty($this->tags)) {
-                $createLogGroupArguments['tags'] = $this->tags;
-            }
-
-            $this
-                ->client
-                ->createLogGroup($createLogGroupArguments);
-
-            if ($this->retention !== null) {
-                $this
-                    ->client
-                    ->putRetentionPolicy(
-                        [
-                            'logGroupName' => $this->group,
-                            'retentionInDays' => $this->retention,
-                        ]
-                    );
-            }
+                ->putRetentionPolicy(
+                    [
+                        'logGroupName' => $this->group,
+                        'retentionInDays' => $this->retention,
+                    ]
+                );
         }
     }
 
@@ -373,40 +363,24 @@ class CloudWatch extends AbstractProcessingHandler
             $this->initializeGroup();
         }
 
-        $this->refreshSequenceToken();
+        $this->initializeStream();
     }
 
-    private function refreshSequenceToken(): void
+    private function initializeStream(): void
     {
-        // fetch existing streams
-        $existingStreams =
-            $this
-                ->client
-                ->describeLogStreams(
-                    [
-                        'logGroupName' => $this->group,
-                        'logStreamNamePrefix' => $this->stream,
-                    ]
-                )->get('logStreams');
-
-        // extract existing streams names
-        $existingStreamsNames = array_map(
-            function ($stream) {
-                return $stream['logStreamName'];
-            },
-            $existingStreams
-        );
-
-        // create stream if not created
-        if (!in_array($this->stream, $existingStreamsNames, true)) {
+        try {
             $this
                 ->client
                 ->createLogStream(
                     [
                         'logGroupName' => $this->group,
-                        'logStreamName' => $this->stream
+                        'logStreamName' => $this->stream,
                     ]
                 );
+        } catch (\Aws\CloudWatchLogs\Exception\CloudWatchLogsException $e) {
+            if ($e->getAwsErrorCode() !== 'ResourceAlreadyExistsException') {
+                throw $e;
+            }
         }
 
         $this->initialized = true;

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -40,7 +40,7 @@ class CloudWatch extends AbstractProcessingHandler
     private $stream;
 
     /**
-     * @var integer
+     * @var int|null
      */
     private $retention;
 
@@ -101,7 +101,7 @@ class CloudWatch extends AbstractProcessingHandler
      *  The ':' (colon) and '*' (asterisk) characters are not allowed.
      * @param string $stream
      *
-     * @param int $retention
+     * @param int|null $retention Days to retain logs. Pass null for indefinite retention.
      * @param int $batchSize
      * @param array $tags
      * @param int $level
@@ -114,7 +114,7 @@ class CloudWatch extends AbstractProcessingHandler
         CloudWatchLogsClient $client,
         $group,
         $stream,
-        $retention = 14,
+        ?int $retention = 14,
         $batchSize = 10000,
         array $tags = [],
         $level = Logger::DEBUG,
@@ -228,7 +228,7 @@ class CloudWatch extends AbstractProcessingHandler
     }
 
     /**
-     * Event size in the batch can not be bigger than 256 KB
+     * Each log event can not be bigger than 1 MB.
      * https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
      *
      * @param array $entry
@@ -263,8 +263,8 @@ class CloudWatch extends AbstractProcessingHandler
      *
      * @param array $entries
      *
-     * @throws \Aws\CloudWatchLogs\Exception\CloudWatchLogsException Thrown by putLogEvents for example in case of an
-     *                                                               invalid sequence token
+     * @throws \Aws\CloudWatchLogs\Exception\CloudWatchLogsException Thrown by putLogEvents on AWS-side errors
+     *                                                               (e.g. IAM denial, persistent throttling).
      */
     private function send(array $entries): void
     {
@@ -368,7 +368,7 @@ class CloudWatch extends AbstractProcessingHandler
     /**
      * Flush buffered records to CloudWatch immediately.
      *
-     * Useful for long-living workers (Laravel queues, Symfony messenger,
+     * Useful for long-lived workers (Laravel queues, Symfony messenger,
      * PHP-FPM with persistent state) that cannot rely on close() being called.
      */
     public function flush(): void

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -11,11 +11,6 @@ use Monolog\Logger;
 class CloudWatch extends AbstractProcessingHandler
 {
     /**
-     * Requests per second limit (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html)
-     */
-    const RPS_LIMIT = 5;
-
-    /**
      * Event size limit (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html)
      *
      * @var int
@@ -87,16 +82,6 @@ class CloudWatch extends AbstractProcessingHandler
     private $currentDataAmount = 0;
 
     /**
-     * @var int
-     */
-    private $remainingRequests = self::RPS_LIMIT;
-
-    /**
-     * @var \DateTime
-     */
-    private $savedTime;
-
-    /**
      * @var int|null
      */
     private $earliestTimestamp = null;
@@ -149,8 +134,6 @@ class CloudWatch extends AbstractProcessingHandler
         $this->createGroup = $createGroup;
 
         parent::__construct($level, $bubble);
-
-        $this->savedTime = new \DateTime;
     }
 
     /**
@@ -207,24 +190,6 @@ class CloudWatch extends AbstractProcessingHandler
             // clear data amount
             $this->currentDataAmount = 0;
         }
-    }
-
-    private function checkThrottle(): void
-    {
-        $current = new \DateTime();
-        $diff = $current->diff($this->savedTime)->s;
-        $sameSecond = $diff === 0;
-
-        if ($sameSecond && $this->remainingRequests > 0) {
-            $this->remainingRequests--;
-        } elseif ($sameSecond && $this->remainingRequests === 0) {
-            sleep(1);
-            $this->remainingRequests = self::RPS_LIMIT;
-        } elseif (!$sameSecond) {
-            $this->remainingRequests = self::RPS_LIMIT;
-        }
-
-        $this->savedTime = new \DateTime();
     }
 
     /**
@@ -319,8 +284,6 @@ class CloudWatch extends AbstractProcessingHandler
             'logStreamName' => $this->stream,
             'logEvents' => $entries
         ];
-
-        $this->checkThrottle();
 
         $this->client->putLogEvents($data);
     }

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -20,7 +20,7 @@ class CloudWatch extends AbstractProcessingHandler
      *
      * @var int
      */
-    const EVENT_SIZE_LIMIT = 262118; // 262144 - reserved 26
+    const EVENT_SIZE_LIMIT = 1048550; // 1048576 (1 MB) - reserved 26 byte AWS overhead
 
     /**
      * The batch of log events in a single PutLogEvents request cannot span more than 24 hours.

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -450,4 +450,24 @@ class CloudWatch extends AbstractProcessingHandler
     {
         $this->flushBuffer();
     }
+
+    /**
+     * Flush buffered records to CloudWatch immediately.
+     *
+     * Useful for long-living workers (Laravel queues, Symfony messenger,
+     * PHP-FPM with persistent state) that cannot rely on close() being called.
+     */
+    public function flush(): void
+    {
+        $this->flushBuffer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(): void
+    {
+        $this->flush();
+        parent::reset();
+    }
 }

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -114,7 +114,7 @@ class CloudWatch extends AbstractProcessingHandler
         CloudWatchLogsClient $client,
         $group,
         $stream,
-        ?int $retention = 14,
+        $retention = 14,
         $batchSize = 10000,
         array $tags = [],
         $level = Logger::DEBUG,
@@ -290,33 +290,43 @@ class CloudWatch extends AbstractProcessingHandler
 
     private function initializeGroup(): void
     {
-        $createLogGroupArguments = ['logGroupName' => $this->group];
-
-        if (!empty($this->tags)) {
-            $createLogGroupArguments['tags'] = $this->tags;
-        }
-
-        $created = false;
-        try {
-            $this->client->createLogGroup($createLogGroupArguments);
-            $created = true;
-        } catch (\Aws\CloudWatchLogs\Exception\CloudWatchLogsException $e) {
-            if ($e->getAwsErrorCode() !== 'ResourceAlreadyExistsException') {
-                throw $e;
-            }
-        }
-
-        // Only set retention on freshly-created groups. Externally-managed retention
-        // (Terraform, manual, infra-as-code) must not be silently overwritten on each init.
-        if ($created && $this->retention !== null) {
+        // fetch existing groups
+        $existingGroups =
             $this
                 ->client
-                ->putRetentionPolicy(
-                    [
-                        'logGroupName' => $this->group,
-                        'retentionInDays' => $this->retention,
-                    ]
-                );
+                ->describeLogGroups(['logGroupNamePrefix' => $this->group])
+                ->get('logGroups');
+
+        // extract existing groups names
+        $existingGroupsNames = array_map(
+            function ($group) {
+                return $group['logGroupName'];
+            },
+            $existingGroups
+        );
+
+        // create group and set retention policy if not created yet
+        if (!in_array($this->group, $existingGroupsNames, true)) {
+            $createLogGroupArguments = ['logGroupName' => $this->group];
+
+            if (!empty($this->tags)) {
+                $createLogGroupArguments['tags'] = $this->tags;
+            }
+
+            $this
+                ->client
+                ->createLogGroup($createLogGroupArguments);
+
+            if ($this->retention !== null) {
+                $this
+                    ->client
+                    ->putRetentionPolicy(
+                        [
+                            'logGroupName' => $this->group,
+                            'retentionInDays' => $this->retention,
+                        ]
+                    );
+            }
         }
     }
 
@@ -331,7 +341,27 @@ class CloudWatch extends AbstractProcessingHandler
 
     private function initializeStream(): void
     {
-        try {
+        // fetch existing streams
+        $existingStreams =
+            $this
+                ->client
+                ->describeLogStreams(
+                    [
+                        'logGroupName' => $this->group,
+                        'logStreamNamePrefix' => $this->stream,
+                    ]
+                )->get('logStreams');
+
+        // extract existing streams names
+        $existingStreamsNames = array_map(
+            function ($stream) {
+                return $stream['logStreamName'];
+            },
+            $existingStreams
+        );
+
+        // create stream if not created yet
+        if (!in_array($this->stream, $existingStreamsNames, true)) {
             $this
                 ->client
                 ->createLogStream(
@@ -340,10 +370,6 @@ class CloudWatch extends AbstractProcessingHandler
                         'logStreamName' => $this->stream,
                     ]
                 );
-        } catch (\Aws\CloudWatchLogs\Exception\CloudWatchLogsException $e) {
-            if ($e->getAwsErrorCode() !== 'ResourceAlreadyExistsException') {
-                throw $e;
-            }
         }
 
         $this->initialized = true;

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -70,7 +70,6 @@ class CloudWatchTest extends TestCase
             'logStreams' => [
                 [
                     'logStreamName' => $this->streamName,
-                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
                 ]
             ]
         ]);
@@ -108,7 +107,6 @@ class CloudWatchTest extends TestCase
             'logStreams' => [
                 [
                     'logStreamName' => $this->streamName,
-                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
                 ]
             ]
         ]);
@@ -160,7 +158,6 @@ class CloudWatchTest extends TestCase
             'logStreams' => [
                 [
                     'logStreamName' => $this->streamName,
-                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
                 ]
             ]
         ]);
@@ -204,7 +201,6 @@ class CloudWatchTest extends TestCase
             'logStreams' => [
                 [
                     'logStreamName' => $this->streamName,
-                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
                 ]
             ]
         ]);
@@ -257,7 +253,6 @@ class CloudWatchTest extends TestCase
             'logStreams' => [
                 [
                     'logStreamName' => $this->streamName . 'bar',
-                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198324'
                 ]
             ]
         ]);
@@ -416,7 +411,6 @@ class CloudWatchTest extends TestCase
             'logStreams' => [
                 [
                     'logStreamName' => $this->streamName,
-                    'uploadSequenceToken' => '49559307804604887372466686181995921714853186581450198322'
                 ]
             ]
         ]);

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -42,8 +42,10 @@ class CloudWatchTest extends TestCase
                 ->getMockBuilder(CloudWatchLogsClient::class)
                 ->addMethods(
                     [
+                        'describeLogGroups',
                         'createLogGroup',
                         'putRetentionPolicy',
+                        'describeLogStreams',
                         'createLogStream',
                         'putLogEvents',
                     ]
@@ -52,20 +54,35 @@ class CloudWatchTest extends TestCase
                 ->getMock();
     }
 
-    private function resourceAlreadyExistsException(): CloudWatchLogsException
-    {
-        $exception = $this->getMockBuilder(CloudWatchLogsException::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $exception->method('getAwsErrorCode')->willReturn('ResourceAlreadyExistsException');
-
-        return $exception;
-    }
-
     public function testInitializeWithCreateGroupDisabled()
     {
-        $this->clientMock->expects($this->never())->method('createLogGroup');
-        $this->clientMock->expects($this->never())->method('putRetentionPolicy');
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('describeLogGroups');
+
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('createLogGroup');
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName . 'foo',
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
 
         $this
             ->clientMock
@@ -86,29 +103,47 @@ class CloudWatchTest extends TestCase
 
     public function testInitializeWithExistingLogGroup()
     {
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
+
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('createLogGroup')
-            ->with(['logGroupName' => $this->groupName])
-            ->willThrowException($this->resourceAlreadyExistsException());
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
 
-        // Existing groups must NOT have their retention policy reapplied — that would
-        // silently overwrite externally-managed retention (Terraform, manual setup).
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('createLogGroup');
+
         $this
             ->clientMock
             ->expects($this->never())
             ->method('putRetentionPolicy');
 
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName,
+                ]
+            ]
+        ]);
+
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('createLogStream')
+            ->method('describeLogStreams')
             ->with([
                 'logGroupName' => $this->groupName,
-                'logStreamName' => $this->streamName,
+                'logStreamNamePrefix' => $this->streamName,
             ])
-            ->willThrowException($this->resourceAlreadyExistsException());
+            ->willReturn($logStreamResult);
+
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('createLogStream');
 
         $handler = $this->getCUT();
 
@@ -125,6 +160,15 @@ class CloudWatchTest extends TestCase
             'applicationEnvironment' => 'dummyApplicationEnvironment'
         ];
 
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
         $this
             ->clientMock
             ->expects($this->once())
@@ -133,6 +177,24 @@ class CloudWatchTest extends TestCase
                 'logGroupName' => $this->groupName,
                 'tags' => $tags
             ]);
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName . 'foo',
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
 
         $this
             ->clientMock
@@ -153,11 +215,38 @@ class CloudWatchTest extends TestCase
 
     public function testInitializeWithEmptyTags()
     {
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
         $this
             ->clientMock
             ->expects($this->once())
             ->method('createLogGroup')
-            ->with(['logGroupName' => $this->groupName]);
+            ->with(['logGroupName' => $this->groupName]); //The empty array of tags is not handed over
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName . 'foo',
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
 
         $this
             ->clientMock
@@ -178,6 +267,15 @@ class CloudWatchTest extends TestCase
 
     public function testInitializeWithMissingGroupAndStream()
     {
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
         $this
             ->clientMock
             ->expects($this->once())
@@ -192,6 +290,24 @@ class CloudWatchTest extends TestCase
                 'logGroupName' => $this->groupName,
                 'retentionInDays' => 14,
             ]);
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName . 'foo',
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
 
         $this
             ->clientMock
@@ -212,6 +328,15 @@ class CloudWatchTest extends TestCase
 
     public function testInitializeSkipsRetentionWhenNull()
     {
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
         $this
             ->clientMock
             ->expects($this->once())
@@ -221,6 +346,24 @@ class CloudWatchTest extends TestCase
             ->clientMock
             ->expects($this->never())
             ->method('putRetentionPolicy');
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName . 'foo',
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
 
         $this
             ->clientMock
@@ -235,49 +378,31 @@ class CloudWatchTest extends TestCase
         $reflectionMethod->invoke($handler);
     }
 
-    public function testCreateLogGroupNonExistsExceptionBubbles()
+    public function testExceptionFromDescribeLogGroups()
     {
-        // e.g. 'User is not authorized to perform logs:CreateLogGroup'
-        $exception = $this->getMockBuilder(CloudWatchLogsException::class)
+        // e.g. 'User is not authorized to perform logs:DescribeLogGroups'
+        /** @var CloudWatchLogsException */
+        $awsException = $this->getMockBuilder(CloudWatchLogsException::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $exception->method('getAwsErrorCode')->willReturn('AccessDeniedException');
 
+        // if this fails ...
         $this
             ->clientMock
-            ->expects($this->once())
-            ->method('createLogGroup')
-            ->will($this->throwException($exception));
+            ->expects($this->atLeastOnce())
+            ->method('describeLogGroups')
+            ->will($this->throwException($awsException));
+
+        // ... this should not be called:
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('describeLogStreams');
 
         $this->expectException(CloudWatchLogsException::class);
 
-        $handler = $this->getCUT();
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
-    }
-
-    public function testCreateLogStreamNonExistsExceptionBubbles()
-    {
-        $exception = $this->getMockBuilder(CloudWatchLogsException::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $exception->method('getAwsErrorCode')->willReturn('AccessDeniedException');
-
-        $this
-            ->clientMock
-            ->expects($this->once())
-            ->method('createLogStream')
-            ->will($this->throwException($exception));
-
-        $this->expectException(CloudWatchLogsException::class);
-
-        $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, [], Logger::DEBUG, true, false);
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
+        $handler = $this->getCUT(0);
+        $handler->handle($this->getRecord(Logger::INFO));
     }
 
     public function testLimitExceeded()
@@ -367,15 +492,30 @@ class CloudWatchTest extends TestCase
 
     private function prepareMocks()
     {
-        $this
-            ->clientMock
-            ->method('createLogGroup')
-            ->willThrowException($this->resourceAlreadyExistsException());
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
 
         $this
             ->clientMock
-            ->method('createLogStream')
-            ->willThrowException($this->resourceAlreadyExistsException());
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                [
+                    'logStreamName' => $this->streamName,
+                ]
+            ]
+        ]);
+
+        $this
+            ->clientMock
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
 
         $this->awsResultMock =
             $this

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -42,47 +42,39 @@ class CloudWatchTest extends TestCase
                 ->getMockBuilder(CloudWatchLogsClient::class)
                 ->addMethods(
                     [
-                        'describeLogGroups',
-                        'CreateLogGroup',
-                        'PutRetentionPolicy',
-                        'DescribeLogStreams',
-                        'CreateLogStream',
-                        'PutLogEvents'
+                        'createLogGroup',
+                        'putRetentionPolicy',
+                        'createLogStream',
+                        'putLogEvents',
                     ]
                 )
                 ->disableOriginalConstructor()
                 ->getMock();
     }
 
+    private function resourceAlreadyExistsException(): CloudWatchLogsException
+    {
+        $exception = $this->getMockBuilder(CloudWatchLogsException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $exception->method('getAwsErrorCode')->willReturn('ResourceAlreadyExistsException');
+
+        return $exception;
+    }
+
     public function testInitializeWithCreateGroupDisabled()
     {
-        $this
-            ->clientMock
-            ->expects($this->never())
-            ->method('describeLogGroups');
-
-        $this
-            ->clientMock
-            ->expects($this->never())
-            ->method('createLogGroup');
-
-        $logStreamResult = new Result([
-            'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName,
-                ]
-            ]
-        ]);
+        $this->clientMock->expects($this->never())->method('createLogGroup');
+        $this->clientMock->expects($this->never())->method('putRetentionPolicy');
 
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('describeLogStreams')
+            ->method('createLogStream')
             ->with([
                 'logGroupName' => $this->groupName,
-                'logStreamNamePrefix' => $this->streamName,
-            ])
-            ->willReturn($logStreamResult);
+                'logStreamName' => $this->streamName,
+            ]);
 
         $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, [], Logger::DEBUG, true, false);
 
@@ -94,32 +86,29 @@ class CloudWatchTest extends TestCase
 
     public function testInitializeWithExistingLogGroup()
     {
-        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('createLogGroup')
+            ->with(['logGroupName' => $this->groupName])
+            ->willThrowException($this->resourceAlreadyExistsException());
+
+        // Existing groups must NOT have their retention policy reapplied — that would
+        // silently overwrite externally-managed retention (Terraform, manual setup).
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('putRetentionPolicy');
 
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('describeLogGroups')
-            ->with(['logGroupNamePrefix' => $this->groupName])
-            ->willReturn($logGroupsResult);
-
-        $logStreamResult = new Result([
-            'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName,
-                ]
-            ]
-        ]);
-
-        $this
-            ->clientMock
-            ->expects($this->once())
-            ->method('describeLogStreams')
+            ->method('createLogStream')
             ->with([
                 'logGroupName' => $this->groupName,
-                'logStreamNamePrefix' => $this->streamName,
+                'logStreamName' => $this->streamName,
             ])
-            ->willReturn($logStreamResult);
+            ->willThrowException($this->resourceAlreadyExistsException());
 
         $handler = $this->getCUT();
 
@@ -136,15 +125,6 @@ class CloudWatchTest extends TestCase
             'applicationEnvironment' => 'dummyApplicationEnvironment'
         ];
 
-        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
-
-        $this
-            ->clientMock
-            ->expects($this->once())
-            ->method('describeLogGroups')
-            ->with(['logGroupNamePrefix' => $this->groupName])
-            ->willReturn($logGroupsResult);
-
         $this
             ->clientMock
             ->expects($this->once())
@@ -154,23 +134,14 @@ class CloudWatchTest extends TestCase
                 'tags' => $tags
             ]);
 
-        $logStreamResult = new Result([
-            'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName,
-                ]
-            ]
-        ]);
-
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('describeLogStreams')
+            ->method('createLogStream')
             ->with([
                 'logGroupName' => $this->groupName,
-                'logStreamNamePrefix' => $this->streamName,
-            ])
-            ->willReturn($logStreamResult);
+                'logStreamName' => $this->streamName,
+            ]);
 
         $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, $tags);
 
@@ -182,38 +153,20 @@ class CloudWatchTest extends TestCase
 
     public function testInitializeWithEmptyTags()
     {
-        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
-
-        $this
-            ->clientMock
-            ->expects($this->once())
-            ->method('describeLogGroups')
-            ->with(['logGroupNamePrefix' => $this->groupName])
-            ->willReturn($logGroupsResult);
-
         $this
             ->clientMock
             ->expects($this->once())
             ->method('createLogGroup')
-            ->with(['logGroupName' => $this->groupName]); //The empty array of tags is not handed over
-
-        $logStreamResult = new Result([
-            'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName,
-                ]
-            ]
-        ]);
+            ->with(['logGroupName' => $this->groupName]);
 
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('describeLogStreams')
+            ->method('createLogStream')
             ->with([
                 'logGroupName' => $this->groupName,
-                'logStreamNamePrefix' => $this->streamName,
-            ])
-            ->willReturn($logStreamResult);
+                'logStreamName' => $this->streamName,
+            ]);
 
         $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName);
 
@@ -225,15 +178,6 @@ class CloudWatchTest extends TestCase
 
     public function testInitializeWithMissingGroupAndStream()
     {
-        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
-
-        $this
-            ->clientMock
-            ->expects($this->once())
-            ->method('describeLogGroups')
-            ->with(['logGroupNamePrefix' => $this->groupName])
-            ->willReturn($logGroupsResult);
-
         $this
             ->clientMock
             ->expects($this->once())
@@ -249,35 +193,87 @@ class CloudWatchTest extends TestCase
                 'retentionInDays' => 14,
             ]);
 
-        $logStreamResult = new Result([
-            'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName . 'bar',
-                ]
-            ]
-        ]);
-
-        $this
-            ->clientMock
-            ->expects($this->once())
-            ->method('describeLogStreams')
-            ->with([
-                'logGroupName' => $this->groupName,
-                'logStreamNamePrefix' => $this->streamName,
-            ])
-            ->willReturn($logStreamResult);
-
         $this
             ->clientMock
             ->expects($this->once())
             ->method('createLogStream')
             ->with([
                 'logGroupName' => $this->groupName,
-                'logStreamName' => $this->streamName
+                'logStreamName' => $this->streamName,
             ]);
 
         $handler = $this->getCUT();
 
+        $reflection = new \ReflectionClass($handler);
+        $reflectionMethod = $reflection->getMethod('initialize');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($handler);
+    }
+
+    public function testInitializeSkipsRetentionWhenNull()
+    {
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('createLogGroup');
+
+        $this
+            ->clientMock
+            ->expects($this->never())
+            ->method('putRetentionPolicy');
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('createLogStream');
+
+        $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, null);
+
+        $reflection = new \ReflectionClass($handler);
+        $reflectionMethod = $reflection->getMethod('initialize');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($handler);
+    }
+
+    public function testCreateLogGroupNonExistsExceptionBubbles()
+    {
+        // e.g. 'User is not authorized to perform logs:CreateLogGroup'
+        $exception = $this->getMockBuilder(CloudWatchLogsException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $exception->method('getAwsErrorCode')->willReturn('AccessDeniedException');
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('createLogGroup')
+            ->will($this->throwException($exception));
+
+        $this->expectException(CloudWatchLogsException::class);
+
+        $handler = $this->getCUT();
+        $reflection = new \ReflectionClass($handler);
+        $reflectionMethod = $reflection->getMethod('initialize');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($handler);
+    }
+
+    public function testCreateLogStreamNonExistsExceptionBubbles()
+    {
+        $exception = $this->getMockBuilder(CloudWatchLogsException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $exception->method('getAwsErrorCode')->willReturn('AccessDeniedException');
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('createLogStream')
+            ->will($this->throwException($exception));
+
+        $this->expectException(CloudWatchLogsException::class);
+
+        $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, [], Logger::DEBUG, true, false);
         $reflection = new \ReflectionClass($handler);
         $reflectionMethod = $reflection->getMethod('initialize');
         $reflectionMethod->setAccessible(true);
@@ -297,7 +293,7 @@ class CloudWatchTest extends TestCase
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('PutLogEvents')
+            ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
 
         $handler = $this->getCUT(1);
@@ -314,7 +310,7 @@ class CloudWatchTest extends TestCase
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('PutLogEvents')
+            ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
 
         $handler = $this->getCUT(1000);
@@ -330,7 +326,7 @@ class CloudWatchTest extends TestCase
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('PutLogEvents')
+            ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
 
         $handler = $this->getCUT(1000);
@@ -346,7 +342,7 @@ class CloudWatchTest extends TestCase
         $this
             ->clientMock
             ->expects($this->exactly(2))
-            ->method('PutLogEvents')
+            ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
 
         $handler = $this->getCUT(3);
@@ -369,61 +365,17 @@ class CloudWatchTest extends TestCase
         $this->assertEquals($expected, $formatter);
     }
 
-    public function testExceptionFromDescribeLogGroups()
-    {
-        // e.g. 'User is not authorized to perform logs:DescribeLogGroups'
-        /** @var CloudWatchLogsException */
-        $awsException = $this->getMockBuilder(CloudWatchLogsException::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        // if this fails ...
-        $this
-            ->clientMock
-            ->expects($this->atLeastOnce())
-            ->method('describeLogGroups')
-            ->will($this->throwException($awsException));
-
-        // ... this should not be called:
-        $this
-            ->clientMock
-            ->expects($this->never())
-            ->method('describeLogStreams');
-
-        $this->expectException(CloudWatchLogsException::class);
-
-        $handler = $this->getCUT(0);
-        $handler->handle($this->getRecord(Logger::INFO));
-    }
-
     private function prepareMocks()
     {
-        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
+        $this
+            ->clientMock
+            ->method('createLogGroup')
+            ->willThrowException($this->resourceAlreadyExistsException());
 
         $this
             ->clientMock
-            ->expects($this->once())
-            ->method('describeLogGroups')
-            ->with(['logGroupNamePrefix' => $this->groupName])
-            ->willReturn($logGroupsResult);
-
-        $logStreamResult = new Result([
-            'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName,
-                ]
-            ]
-        ]);
-
-        $this
-            ->clientMock
-            ->expects($this->once())
-            ->method('describeLogStreams')
-            ->with([
-                'logGroupName' => $this->groupName,
-                'logStreamNamePrefix' => $this->streamName,
-            ])
-            ->willReturn($logStreamResult);
+            ->method('createLogStream')
+            ->willThrowException($this->resourceAlreadyExistsException());
 
         $this->awsResultMock =
             $this
@@ -440,7 +392,7 @@ class CloudWatchTest extends TestCase
         $this
             ->clientMock
             ->expects($this->once())
-            ->method('PutLogEvents')
+            ->method('putLogEvents')
             ->willReturnCallback(function (array $data) {
                 $this->assertStringContainsString('record1', $data['logEvents'][0]['message']);
                 $this->assertStringContainsString('record2', $data['logEvents'][1]['message']);
@@ -477,7 +429,7 @@ class CloudWatchTest extends TestCase
         $this
             ->clientMock
                 ->expects($this->exactly(3))
-                ->method('PutLogEvents')
+                ->method('putLogEvents')
                 ->willReturnCallback(function (array $data) {
                     /** @var int|null */
                     $earliestTime = null;

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -312,6 +312,38 @@ class CloudWatchTest extends TestCase
         $handler->close();
     }
 
+    public function testFlushSendsBufferedRecords()
+    {
+        $this->prepareMocks();
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('PutLogEvents')
+            ->willReturn($this->awsResultMock);
+
+        $handler = $this->getCUT(1000);
+
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->flush();
+    }
+
+    public function testResetFlushesBuffer()
+    {
+        $this->prepareMocks();
+
+        $this
+            ->clientMock
+            ->expects($this->once())
+            ->method('PutLogEvents')
+            ->willReturn($this->awsResultMock);
+
+        $handler = $this->getCUT(1000);
+
+        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->reset();
+    }
+
     public function testSendsBatches()
     {
         $this->prepareMocks();


### PR DESCRIPTION
v2.1.0 maintenance release. No breaking changes.

- Per-event size limit 256 KB → 1 MB (#101)
- Drop sequence token tracking (AWS deprecated server-side)
- Drop 5 RPS self-throttle (#111, #114)
- Public `flush()` + override `reset()` for long-lived workers (#95)
- README: IAM Task Role section for ECS/EC2 (#103)
- Docker dev env + CI matrix on PHP 8.2–8.5

Closes #95, #101, #103, #111, #114. Adopts #102, #115.