### PR TITLE
Fix CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # AWS CloudWatch Logs Handler for Monolog
 
-[![Actions Status](https://github.com/maxbanton/cwh/workflows/Pipeline/badge.svg)](https://github.com/maxbanton/cwh/actions)
+[![CI](https://github.com/maxbanton/cwh/actions/workflows/php.yml/badge.svg?branch=master)](https://github.com/maxbanton/cwh/actions/workflows/php.yml)
 [![Coverage Status](https://img.shields.io/coveralls/maxbanton/cwh/master.svg)](https://coveralls.io/github/maxbanton/cwh?branch=master)
 [![License](https://img.shields.io/packagist/l/maxbanton/cwh.svg)](https://github.com/maxbanton/cwh/blob/master/LICENSE)
 [![Version](https://img.shields.io/packagist/v/maxbanton/cwh.svg)](https://packagist.org/packages/maxbanton/cwh)


### PR DESCRIPTION
Workflow renamed from `Pipeline` to `CI` (in `.github/workflows/php.yml`). Old badge URL points to a non-existent workflow and renders as a broken image. Switching to the modern `actions/workflows/<file>.yml/badge.svg?branch=master` URL — stable against future renames.