### PR TITLE
v3.0.0 — PHP 8.1 + Monolog 3 modernization

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.2", "8.3", "8.4", "8.5"]
+        php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
 
@@ -28,6 +28,9 @@ jobs:
 
       - name: Lint
         run: make PHP=${{ matrix.php }} lint
+
+      - name: Static analysis
+        run: make PHP=${{ matrix.php }} analyse
 
       - name: Tests
         run: make PHP=${{ matrix.php }} test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - YYYY-MM-DD
+
+### Added
+
+- `$createStream` constructor argument (10th, default `true`). Set to `false` to skip `DescribeLogStreams` + `CreateLogStream` when the log stream is provisioned out of band (e.g. via Terraform). Lets users drop the matching IAM permissions.
+- Full type coverage on the constructor and properties (constructor promotion, `readonly` for immutable state).
+- `phpstan` (level 8) runs in CI alongside lint and tests.
+
+### Changed
+
+- Coding standard upgraded from PSR-2 to PSR-12.
+- PHPUnit upgraded to `^10.5 || ^11.0`.
+
+### Removed
+
+- Support for PHP 7.x and 8.0. Minimum PHP is now `^8.1`.
+- Support for Monolog 2. Minimum Monolog is now `^3.0`.
+
+### Migration
+
+- Replace any `Monolog\Logger::DEBUG` (or other level constant) usage with `Monolog\Level::Debug`. The `$level` constructor argument continues to accept `int|string|Level` so string values like `'debug'` keep working.
+- Symfony service definitions referencing `!php/const Monolog\Logger::WARNING` must change to `!php/const Monolog\Level::Warning`.
+- Subclasses overriding `protected function write(array $record): void` must update the signature to `protected function write(\Monolog\LogRecord $record): void` and access fields via `->property` instead of `['key']`.
+- The constructor parameter order, names, and defaults of the existing 9 arguments are unchanged. Existing Symfony positional `arguments:` lists and Laravel `with`/`handler_with` named-key configs continue to work after the platform upgrades above.
+
 ## [2.1.0] - 2026-04-26
 
 ### Added
@@ -36,5 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **No breaking public API changes.** Adds public `flush()` and overrides `reset()` to flush. Existing constructor and method signatures are unchanged; existing `^2.0` pins continue to work without modification.
 - Minimum PHP / Monolog versions unchanged (`^7.2 || ^8` / `monolog/monolog: ^2.0`). CI tests PHP 8.2 – 8.5; no code paths require newer PHP.
 
-[Unreleased]: https://github.com/maxbanton/cwh/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/maxbanton/cwh/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/maxbanton/cwh/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/maxbanton/cwh/compare/v2.0.4...v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0] - YYYY-MM-DD
+## [3.0.0] - 2026-05-03
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,18 @@
 
 Changes that are cosmetic in nature and do not add anything substantial to the stability, functionality, or testability will generally not be accepted.
 
+#### **Local development**
+
+Use the Makefile targets — they run inside Docker against the supported PHP matrix and exactly match what CI runs. Direct `phpunit`/`phpcs`/`phpstan` invocations on your host may pick up a different PHP version or dependency set:
+
+```bash
+make build-svc PHP=8.4    # build the dev container
+make install   PHP=8.4    # composer install inside it
+make lint                 # PSR-12 lint via phpcs
+make lint-fix             # auto-fix PSR-12 violations via phpcbf
+make analyse              # phpstan level 8
+make test                 # PHPUnit
+make matrix               # run install + lint + test across PHP 8.1–8.5 in parallel
+```
+
 Thanks!

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ test-coverage:
 	$(DC) vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
 
 lint:
-	$(DC) vendor/bin/phpcs --standard=psr2 --ignore=Tests src/
+	$(DC) vendor/bin/phpcs --standard=PSR12 --ignore=Tests src/
 
 lint-fix:
-	$(DC) vendor/bin/phpcbf --standard=psr2 --ignore=Tests src/
+	$(DC) vendor/bin/phpcbf --standard=PSR12 --ignore=Tests src/
 
 analyse:
 	$(DC) vendor/bin/phpstan analyse --level=8 src/
@@ -40,7 +40,7 @@ shell:
 	$(DC) bash
 
 matrix:
-	@printf '8.2\n8.3\n8.4\n8.5\n' | xargs -n1 -P4 -I{} $(MAKE) PHP={} install ci
+	@printf '8.1\n8.2\n8.3\n8.4\n8.5\n' | xargs -n1 -P5 -I{} $(MAKE) PHP={} install ci
 
 clean:
 	$(COMPOSE) down -v

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Please press **&#9733; Star** button if you find this library useful.
 This library uses AWS API through AWS PHP SDK, which has limits on concurrent requests. It means that on high concurrent or high load applications it may not work on it's best way. Please consider using another solution such as logging to the stdout and redirecting logs with fluentd.
 
 ## Requirements
-* PHP ^7.3
+* PHP ^8.1
+* Monolog ^3.0
 * AWS account with proper permissions (see list of permissions below)
 
 ## Features
@@ -32,7 +33,7 @@ This library uses AWS API through AWS PHP SDK, which has limits on concurrent re
 Install the latest version with [Composer](https://getcomposer.org/) by running
 
 ```bash
-$ composer require maxbanton/cwh:^2.0
+$ composer require maxbanton/cwh:^3.0
 ```
 
 ## Basic Usage
@@ -41,8 +42,9 @@ $ composer require maxbanton/cwh:^2.0
 
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Maxbanton\Cwh\Handler\CloudWatch;
-use Monolog\Logger;
 use Monolog\Formatter\JsonFormatter;
+use Monolog\Level;
+use Monolog\Logger;
 
 $sdkParams = [
     'region' => 'eu-west-1',
@@ -67,7 +69,12 @@ $streamName = 'ec2-instance-1';
 $retentionDays = 30;
 
 // Instantiate handler (tags are optional)
-$handler = new CloudWatch($client, $groupName, $streamName, $retentionDays, 10000, ['my-awesome-tag' => 'tag-value']);
+$handler = new CloudWatch($client, $groupName, $streamName, $retentionDays, 10000, ['my-awesome-tag' => 'tag-value'], Level::Debug);
+
+// Set $createStream to false (10th argument) when the log stream is provisioned out of band
+// (e.g. via Terraform `aws_cloudwatch_log_stream`). This skips DescribeLogStreams + CreateLogStream
+// and lets you drop the matching IAM permissions.
+// $handler = new CloudWatch($client, $groupName, $streamName, $retentionDays, 10000, [], Level::Debug, true, true, false);
 
 // Optionally set the JsonFormatter to be able to access your log messages in a structured way
 $handler->setFormatter(new JsonFormatter());
@@ -106,12 +113,24 @@ $client = new CloudWatchLogsClient([
 ```
 
 ## Frameworks integration
- - [Silex](http://silex.sensiolabs.org/doc/master/providers/monolog.html#customization)
- - [Symfony](http://symfony.com/doc/current/logging.html) ([Example](https://github.com/maxbanton/cwh/issues/10#issuecomment-296173601))
- - [Lumen](https://lumen.laravel.com/docs/5.2/errors)
- - [Laravel](https://laravel.com/docs/5.4/errors) ([Example](https://stackoverflow.com/a/51790656/1856778))
-  
+ - [Symfony](https://symfony.com/doc/current/logging.html) ([Example](https://github.com/maxbanton/cwh/issues/10#issuecomment-296173601))
+ - [Laravel](https://laravel.com/docs/12.x/logging) ([Example](https://stackoverflow.com/a/51790656/1856778))
+
  [And many others](https://github.com/Seldaek/monolog#framework-integrations)
+
+## Migrating from 2.x to 3.x
+
+3.x is a breaking release that drops Monolog 2 and PHP 7.x support. The constructor parameter order, names, and defaults are preserved — existing Symfony YAML and Laravel `with`/`handler_with` configs continue to work after the platform upgrades below.
+
+**Required changes:**
+- Bump PHP to 8.1 or newer.
+- Bump Monolog to 3.x.
+- The `Monolog\Logger::DEBUG` (and other) constants were removed in Monolog 3. Use `Monolog\Level::Debug` instead — `int|string|Level` are all accepted by the `$level` constructor argument.
+- Symfony service definitions referencing `!php/const Monolog\Logger::WARNING` must change to `!php/const Monolog\Level::Warning`.
+- Laravel channels using `'level' => 'warning'` (string form) keep working unchanged.
+
+**New (optional):**
+- A 10th constructor argument `$createStream` (default `true`). Set to `false` to skip `DescribeLogStreams`/`CreateLogStream` for pre-provisioned streams; lets you drop those IAM permissions.
  
 # AWS IAM needed permissions
 if you prefer to use a separate programmatic IAM user (recommended) or want to define a policy, make sure following permissions are included:
@@ -122,7 +141,9 @@ if you prefer to use a separate programmatic IAM user (recommended) or want to d
 1. `DescribeLogStreams` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html)
 1. `DescribeLogGroups` [aws docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html)
 
-When setting the `$createGroup` argument to `false`, permissions `DescribeLogGroups` and `CreateLogGroup` can be omitted
+When setting the `$createGroup` argument to `false`, permissions `DescribeLogGroups` and `CreateLogGroup` can be omitted.
+
+When setting the `$createStream` argument to `false`, permissions `DescribeLogStreams` and `CreateLogStream` can be omitted. Use this when the log stream is provisioned out of band (e.g. via Terraform). If the stream does not exist at runtime, `PutLogEvents` will fail with `ResourceNotFoundException`.
 
 ## AWS IAM Policy full json example
 ```json

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,16 @@
 services:
+  php81:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        PHP_VERSION: '8.1'
+    working_dir: /app
+    volumes:
+      - .:/app
+      - composer-cache:/tmp/composer
+      - vendor-81:/app/vendor
+
   php82:
     build:
       context: .
@@ -49,6 +61,7 @@ services:
 
 volumes:
   composer-cache:
+  vendor-81:
   vendor-82:
   vendor-83:
   vendor-84:

--- a/composer.json
+++ b/composer.json
@@ -21,19 +21,22 @@
     "source": "https://github.com/maxbanton/cwh"
   },
   "require": {
-    "php": "^7.2 || ^8",
-    "monolog/monolog": "^2.0",
-    "aws/aws-sdk-php": "^3.18"
+    "php": "^8.1",
+    "aws/aws-sdk-php": "^3.18",
+    "monolog/monolog": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5 || ^9.4",
-    "squizlabs/php_codesniffer": "^3.5"
+    "phpstan/phpstan": "^1.11",
+    "phpunit/phpunit": "^10.5 || ^11.0",
+    "squizlabs/php_codesniffer": "^3.10"
   },
   "suggest": {
     "maxbanton/dd": "Minimalistic dump-and-die function for easy debugging"
   },
   "config": {
-    "preferred-install": "dist"
+    "allow-plugins": {},
+    "preferred-install": "dist",
+    "sort-packages": true
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": "^8.1",
-    "aws/aws-sdk-php": "^3.18",
+    "aws/aws-sdk-php": "^3.0",
     "monolog/monolog": "^3.0"
   },
   "require-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+parameters:
+    level: 8
+    paths:
+        - src
+    treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        # User-facing $level accepts int|string|Level for ergonomics.
+        # Monolog\Logger::toMonologLevel() narrows internally; broader type is intentional.
+        -
+            message: '#Parameter \#1 \$level of static method Monolog\\Logger::toMonologLevel\(\) expects.*int\|Monolog\\Level\|string given\.#'
+            path: src/Handler/CloudWatch.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false">
- <coverage>
-    <include>
-      <directory>src</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Handler Test Suite">
-      <directory suffix="Test.php">./tests/</directory>
-    </testsuite>
-  </testsuites>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         backupGlobals="false"
+         backupStaticProperties="false"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Handler Test Suite">
+            <directory suffix="Test.php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -6,149 +6,89 @@ use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
 use Monolog\Logger;
+use Monolog\LogRecord;
 
 class CloudWatch extends AbstractProcessingHandler
 {
     /**
      * Event size limit (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html)
-     *
-     * @var int
      */
-    const EVENT_SIZE_LIMIT = 1048550; // 1048576 (1 MB) - reserved 26 byte AWS overhead
+    final public const EVENT_SIZE_LIMIT = 1048550; // 1048576 (1 MB) - reserved 26 byte AWS overhead
 
     /**
      * The batch of log events in a single PutLogEvents request cannot span more than 24 hours.
-     *
-     * @var int
      */
-    const TIMESPAN_LIMIT = 86400000;
-
-    /**
-     * @var CloudWatchLogsClient
-     */
-    private $client;
-
-    /**
-     * @var string
-     */
-    private $group;
-
-    /**
-     * @var string
-     */
-    private $stream;
-
-    /**
-     * @var int|null
-     */
-    private $retention;
-
-    /**
-     * @var bool
-     */
-    private $initialized = false;
-
-    /**
-     * @var int
-     */
-    private $batchSize;
-
-    /**
-     * @var array
-     */
-    private $buffer = [];
-
-    /**
-     * @var array
-     */
-    private $tags = [];
-
-    /**
-     * @var bool
-     */
-    private $createGroup;
+    final public const TIMESPAN_LIMIT = 86400000;
 
     /**
      * Data amount limit (http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
-     *
-     * @var int
      */
-    private $dataAmountLimit = 1048576;
+    private const DATA_AMOUNT_LIMIT = 1048576;
+
+    private bool $initialized = false;
+
+    /** @var array<int, array{message: string, timestamp: int|float}> */
+    private array $buffer = [];
+
+    private int $currentDataAmount = 0;
+
+    private int|null $earliestTimestamp = null;
 
     /**
-     * @var int
-     */
-    private $currentDataAmount = 0;
-
-    /**
-     * @var int|null
-     */
-    private $earliestTimestamp = null;
-
-    /**
-     * CloudWatchLogs constructor.
      * @param CloudWatchLogsClient $client
      *
-     *  Log group names must be unique within a region for an AWS account.
-     *  Log group names can be between 1 and 512 characters long.
-     *  Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen),
+     * Log group names must be unique within a region for an AWS account.
+     * Log group names can be between 1 and 512 characters long.
+     * Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen),
      * '/' (forward slash), and '.' (period).
      * @param string $group
      *
-     *  Log stream names must be unique within the log group.
-     *  Log stream names can be between 1 and 512 characters long.
-     *  The ':' (colon) and '*' (asterisk) characters are not allowed.
+     * Log stream names must be unique within the log group.
+     * Log stream names can be between 1 and 512 characters long.
+     * The ':' (colon) and '*' (asterisk) characters are not allowed.
      * @param string $stream
      *
      * @param int|null $retention Days to retain logs. Pass null for indefinite retention.
      * @param int $batchSize
-     * @param array $tags
-     * @param int $level
+     * @param array<string, string> $tags
+     * @param int|string|Level $level
      * @param bool $bubble
-     * @param bool $createGroup
-     *
-     * @throws \Exception
+     * @param bool $createGroup Whether to create the log group if it does not exist.
+     * @param bool $createStream Whether to verify/create the log stream. Set to false to skip
+     *                          DescribeLogStreams + CreateLogStream when the stream is provisioned
+     *                          out of band (e.g. via Terraform). Drops the matching IAM permissions.
      */
     public function __construct(
-        CloudWatchLogsClient $client,
-        $group,
-        $stream,
-        $retention = 14,
-        $batchSize = 10000,
-        array $tags = [],
-        $level = Logger::DEBUG,
-        $bubble = true,
-        $createGroup = true
+        private readonly CloudWatchLogsClient $client,
+        private readonly string $group,
+        private readonly string $stream,
+        private readonly ?int $retention = 14,
+        private readonly int $batchSize = 10000,
+        private readonly array $tags = [],
+        int|string|Level $level = Level::Debug,
+        bool $bubble = true,
+        private readonly bool $createGroup = true,
+        private readonly bool $createStream = true,
     ) {
-        if ($batchSize > 10000) {
+        if ($this->batchSize > 10000) {
             throw new \InvalidArgumentException('Batch size can not be greater than 10000');
         }
 
-        $this->client = $client;
-        $this->group = $group;
-        $this->stream = $stream;
-        $this->retention = $retention;
-        $this->batchSize = $batchSize;
-        $this->tags = $tags;
-        $this->createGroup = $createGroup;
-
-        parent::__construct($level, $bubble);
+        parent::__construct(Logger::toMonologLevel($level), $bubble);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         $records = $this->formatRecords($record);
 
-        foreach ($records as $record) {
-            if ($this->willMessageSizeExceedLimit($record) || $this->willMessageTimestampExceedLimit($record)) {
+        foreach ($records as $entry) {
+            if ($this->willMessageSizeExceedLimit($entry) || $this->willMessageTimestampExceedLimit($entry)) {
                 $this->flushBuffer();
             }
 
-            $this->addToBuffer($record);
+            $this->addToBuffer($entry);
 
             if (count($this->buffer) >= $this->batchSize) {
                 $this->flushBuffer();
@@ -157,13 +97,13 @@ class CloudWatch extends AbstractProcessingHandler
     }
 
     /**
-     * @param array $record
+     * @param array{message: string, timestamp: int|float} $record
      */
     private function addToBuffer(array $record): void
     {
         $this->currentDataAmount += $this->getMessageSize($record);
 
-        $timestamp = $record['timestamp'];
+        $timestamp = (int) $record['timestamp'];
 
         if (!$this->earliestTimestamp || $timestamp < $this->earliestTimestamp) {
             $this->earliestTimestamp = $timestamp;
@@ -195,10 +135,9 @@ class CloudWatch extends AbstractProcessingHandler
     /**
      * http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
      *
-     * @param array $record
-     * @return int
+     * @param array{message: string, timestamp: int|float} $record
      */
-    private function getMessageSize($record): int
+    private function getMessageSize(array $record): int
     {
         return strlen($record['message']) + 26;
     }
@@ -207,43 +146,41 @@ class CloudWatch extends AbstractProcessingHandler
      * Determine whether the specified record's message size in addition to the
      * size of the current queued messages will exceed AWS CloudWatch's limit.
      *
-     * @param array $record
-     * @return bool
+     * @param array{message: string, timestamp: int|float} $record
      */
     protected function willMessageSizeExceedLimit(array $record): bool
     {
-        return $this->currentDataAmount + $this->getMessageSize($record) >= $this->dataAmountLimit;
+        return $this->currentDataAmount + $this->getMessageSize($record) >= self::DATA_AMOUNT_LIMIT;
     }
 
     /**
      * Determine whether the specified record's timestamp exceeds the 24 hour timespan limit
      * for all batched messages written in a single call to PutLogEvents.
      *
-     * @param array $record
-     * @return bool
+     * @param array{message: string, timestamp: int|float} $record
      */
     protected function willMessageTimestampExceedLimit(array $record): bool
     {
-        return $this->earliestTimestamp && $record['timestamp'] - $this->earliestTimestamp > self::TIMESPAN_LIMIT;
+        return $this->earliestTimestamp !== null
+            && $record['timestamp'] - $this->earliestTimestamp > self::TIMESPAN_LIMIT;
     }
 
     /**
      * Each log event can not be bigger than 1 MB.
      * https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
      *
-     * @param array $entry
-     * @return array
+     * @return array<int, array{message: string, timestamp: int|float}>
      */
-    private function formatRecords(array $entry): array
+    private function formatRecords(LogRecord $entry): array
     {
-        $entries = str_split($entry['formatted'], self::EVENT_SIZE_LIMIT);
-        $timestamp = $entry['datetime']->format('U.u') * 1000;
+        $entries = str_split($entry->formatted, self::EVENT_SIZE_LIMIT);
+        $timestamp = (int) ($entry->datetime->format('U.u') * 1000);
         $records = [];
 
-        foreach ($entries as $entry) {
+        foreach ($entries as $chunk) {
             $records[] = [
-                'message' => $entry,
-                'timestamp' => $timestamp
+                'message' => $chunk,
+                'timestamp' => $timestamp,
             ];
         }
 
@@ -261,7 +198,7 @@ class CloudWatch extends AbstractProcessingHandler
      *  - The maximum number of log events in a batch is 10,000.
      *  - A batch of log events in a single request cannot span more than 24 hours. Otherwise, the operation fails.
      *
-     * @param array $entries
+     * @param array<int, array{message: string, timestamp: int|float}> $entries
      *
      * @throws \Aws\CloudWatchLogs\Exception\CloudWatchLogsException Thrown by putLogEvents on AWS-side errors
      *                                                               (e.g. IAM denial, persistent throttling).
@@ -269,43 +206,24 @@ class CloudWatch extends AbstractProcessingHandler
     private function send(array $entries): void
     {
         // AWS expects to receive entries in chronological order...
-        usort($entries, static function (array $a, array $b) {
-            if ($a['timestamp'] < $b['timestamp']) {
-                return -1;
-            } elseif ($a['timestamp'] > $b['timestamp']) {
-                return 1;
-            }
+        usort($entries, static fn (array $a, array $b): int => $a['timestamp'] <=> $b['timestamp']);
 
-            return 0;
-        });
-
-        $data = [
+        $this->client->putLogEvents([
             'logGroupName' => $this->group,
             'logStreamName' => $this->stream,
-            'logEvents' => $entries
-        ];
-
-        $this->client->putLogEvents($data);
+            'logEvents' => $entries,
+        ]);
     }
 
     private function initializeGroup(): void
     {
-        // fetch existing groups
-        $existingGroups =
-            $this
-                ->client
-                ->describeLogGroups(['logGroupNamePrefix' => $this->group])
-                ->get('logGroups');
+        $existingGroups = $this
+            ->client
+            ->describeLogGroups(['logGroupNamePrefix' => $this->group])
+            ->get('logGroups');
 
-        // extract existing groups names
-        $existingGroupsNames = array_map(
-            function ($group) {
-                return $group['logGroupName'];
-            },
-            $existingGroups
-        );
+        $existingGroupsNames = array_column($existingGroups, 'logGroupName');
 
-        // create group and set retention policy if not created yet
         if (!in_array($this->group, $existingGroupsNames, true)) {
             $createLogGroupArguments = ['logGroupName' => $this->group];
 
@@ -313,19 +231,13 @@ class CloudWatch extends AbstractProcessingHandler
                 $createLogGroupArguments['tags'] = $this->tags;
             }
 
-            $this
-                ->client
-                ->createLogGroup($createLogGroupArguments);
+            $this->client->createLogGroup($createLogGroupArguments);
 
             if ($this->retention !== null) {
-                $this
-                    ->client
-                    ->putRetentionPolicy(
-                        [
-                            'logGroupName' => $this->group,
-                            'retentionInDays' => $this->retention,
-                        ]
-                    );
+                $this->client->putRetentionPolicy([
+                    'logGroupName' => $this->group,
+                    'retentionInDays' => $this->retention,
+                ]);
             }
         }
     }
@@ -336,56 +248,38 @@ class CloudWatch extends AbstractProcessingHandler
             $this->initializeGroup();
         }
 
-        $this->initializeStream();
-    }
-
-    private function initializeStream(): void
-    {
-        // fetch existing streams
-        $existingStreams =
-            $this
-                ->client
-                ->describeLogStreams(
-                    [
-                        'logGroupName' => $this->group,
-                        'logStreamNamePrefix' => $this->stream,
-                    ]
-                )->get('logStreams');
-
-        // extract existing streams names
-        $existingStreamsNames = array_map(
-            function ($stream) {
-                return $stream['logStreamName'];
-            },
-            $existingStreams
-        );
-
-        // create stream if not created yet
-        if (!in_array($this->stream, $existingStreamsNames, true)) {
-            $this
-                ->client
-                ->createLogStream(
-                    [
-                        'logGroupName' => $this->group,
-                        'logStreamName' => $this->stream,
-                    ]
-                );
+        if ($this->createStream) {
+            $this->initializeStream();
         }
 
         $this->initialized = true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    private function initializeStream(): void
+    {
+        $existingStreams = $this
+            ->client
+            ->describeLogStreams([
+                'logGroupName' => $this->group,
+                'logStreamNamePrefix' => $this->stream,
+            ])
+            ->get('logStreams');
+
+        $existingStreamsNames = array_column($existingStreams, 'logStreamName');
+
+        if (!in_array($this->stream, $existingStreamsNames, true)) {
+            $this->client->createLogStream([
+                'logGroupName' => $this->group,
+                'logStreamName' => $this->stream,
+            ]);
+        }
+    }
+
     protected function getDefaultFormatter(): FormatterInterface
     {
         return new LineFormatter("%channel%: %level_name%: %message% %context% %extra%", null, false, true);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function close(): void
     {
         $this->flushBuffer();
@@ -402,9 +296,6 @@ class CloudWatch extends AbstractProcessingHandler
         $this->flushBuffer();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function reset(): void
     {
         $this->flush();

--- a/tests/Handler/CloudWatchTest.php
+++ b/tests/Handler/CloudWatchTest.php
@@ -2,80 +2,61 @@
 
 namespace Maxbanton\Cwh\Test\Handler;
 
-
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Aws\CloudWatchLogs\Exception\CloudWatchLogsException;
 use Aws\Result;
 use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\LineFormatter;
-use Monolog\Logger;
-use PHPUnit\Framework\TestCase;
+use Monolog\Level;
+use Monolog\LogRecord;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 class CloudWatchTest extends TestCase
 {
-
-    /**
-     * @var MockObject | CloudWatchLogsClient
-     */
+    /** @var MockObject&CloudWatchLogsClient */
     private $clientMock;
 
-    /**
-     * @var MockObject | Result
-     */
+    /** @var MockObject&Result */
     private $awsResultMock;
 
-    /**
-     * @var string
-     */
-    private $groupName = 'group';
+    private string $groupName = 'group';
 
-    /**
-     * @var string
-     */
-    private $streamName = 'stream';
+    private string $streamName = 'stream';
 
     protected function setUp(): void
     {
-        $this->clientMock =
-            $this
-                ->getMockBuilder(CloudWatchLogsClient::class)
-                ->addMethods(
-                    [
-                        'describeLogGroups',
-                        'createLogGroup',
-                        'putRetentionPolicy',
-                        'describeLogStreams',
-                        'createLogStream',
-                        'putLogEvents',
-                    ]
-                )
-                ->disableOriginalConstructor()
-                ->getMock();
+        $this->clientMock = $this
+            ->getMockBuilder(CloudWatchLogsClient::class)
+            ->addMethods([
+                'describeLogGroups',
+                'createLogGroup',
+                'putRetentionPolicy',
+                'describeLogStreams',
+                'createLogStream',
+                'putLogEvents',
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
-    public function testInitializeWithCreateGroupDisabled()
+    public function testInitializeWithCreateGroupDisabled(): void
     {
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->never())
             ->method('describeLogGroups');
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->never())
             ->method('createLogGroup');
 
         $logStreamResult = new Result([
             'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName . 'foo',
-                ]
-            ]
+                ['logStreamName' => $this->streamName . 'foo'],
+            ],
         ]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogStreams')
             ->with([
@@ -84,8 +65,7 @@ class CloudWatchTest extends TestCase
             ])
             ->willReturn($logStreamResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogStream')
             ->with([
@@ -93,45 +73,107 @@ class CloudWatchTest extends TestCase
                 'logStreamName' => $this->streamName,
             ]);
 
-        $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, [], Logger::DEBUG, true, false);
+        $handler = new CloudWatch(
+            $this->clientMock,
+            $this->groupName,
+            $this->streamName,
+            14,
+            10000,
+            [],
+            Level::Debug,
+            true,
+            false,
+        );
 
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
+        $this->invokeInitialize($handler);
     }
 
-    public function testInitializeWithExistingLogGroup()
+    public function testInitializeWithCreateStreamDisabled(): void
     {
         $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogGroups')
             ->with(['logGroupNamePrefix' => $this->groupName])
             ->willReturn($logGroupsResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->never())
             ->method('createLogGroup');
 
-        $this
-            ->clientMock
+        $this->clientMock
+            ->expects($this->never())
+            ->method('describeLogStreams');
+
+        $this->clientMock
+            ->expects($this->never())
+            ->method('createLogStream');
+
+        $handler = new CloudWatch(
+            $this->clientMock,
+            $this->groupName,
+            $this->streamName,
+            14,
+            10000,
+            [],
+            Level::Debug,
+            true,
+            true,
+            false,
+        );
+
+        $this->invokeInitialize($handler);
+    }
+
+    public function testInitializeWithBothCreateFlagsDisabled(): void
+    {
+        $this->clientMock->expects($this->never())->method('describeLogGroups');
+        $this->clientMock->expects($this->never())->method('createLogGroup');
+        $this->clientMock->expects($this->never())->method('describeLogStreams');
+        $this->clientMock->expects($this->never())->method('createLogStream');
+
+        $handler = new CloudWatch(
+            $this->clientMock,
+            $this->groupName,
+            $this->streamName,
+            14,
+            10000,
+            [],
+            Level::Debug,
+            true,
+            false,
+            false,
+        );
+
+        $this->invokeInitialize($handler);
+    }
+
+    public function testInitializeWithExistingLogGroup(): void
+    {
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
+        $this->clientMock
+            ->expects($this->never())
+            ->method('createLogGroup');
+
+        $this->clientMock
             ->expects($this->never())
             ->method('putRetentionPolicy');
 
         $logStreamResult = new Result([
             'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName,
-                ]
-            ]
+                ['logStreamName' => $this->streamName],
+            ],
         ]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogStreams')
             ->with([
@@ -140,54 +182,43 @@ class CloudWatchTest extends TestCase
             ])
             ->willReturn($logStreamResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->never())
             ->method('createLogStream');
 
-        $handler = $this->getCUT();
-
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
+        $this->invokeInitialize($this->getCUT());
     }
 
-    public function testInitializeWithTags()
+    public function testInitializeWithTags(): void
     {
         $tags = [
             'applicationName' => 'dummyApplicationName',
-            'applicationEnvironment' => 'dummyApplicationEnvironment'
+            'applicationEnvironment' => 'dummyApplicationEnvironment',
         ];
 
         $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogGroups')
             ->with(['logGroupNamePrefix' => $this->groupName])
             ->willReturn($logGroupsResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogGroup')
             ->with([
                 'logGroupName' => $this->groupName,
-                'tags' => $tags
+                'tags' => $tags,
             ]);
 
         $logStreamResult = new Result([
             'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName . 'foo',
-                ]
-            ]
+                ['logStreamName' => $this->streamName . 'foo'],
+            ],
         ]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogStreams')
             ->with([
@@ -196,8 +227,7 @@ class CloudWatchTest extends TestCase
             ])
             ->willReturn($logStreamResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogStream')
             ->with([
@@ -207,39 +237,31 @@ class CloudWatchTest extends TestCase
 
         $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, 10000, $tags);
 
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
+        $this->invokeInitialize($handler);
     }
 
-    public function testInitializeWithEmptyTags()
+    public function testInitializeWithEmptyTags(): void
     {
         $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogGroups')
             ->with(['logGroupNamePrefix' => $this->groupName])
             ->willReturn($logGroupsResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogGroup')
-            ->with(['logGroupName' => $this->groupName]); //The empty array of tags is not handed over
+            ->with(['logGroupName' => $this->groupName]); // empty tags array NOT included
 
         $logStreamResult = new Result([
             'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName . 'foo',
-                ]
-            ]
+                ['logStreamName' => $this->streamName . 'foo'],
+            ],
         ]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogStreams')
             ->with([
@@ -248,8 +270,7 @@ class CloudWatchTest extends TestCase
             ])
             ->willReturn($logStreamResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogStream')
             ->with([
@@ -259,31 +280,25 @@ class CloudWatchTest extends TestCase
 
         $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName);
 
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
+        $this->invokeInitialize($handler);
     }
 
-    public function testInitializeWithMissingGroupAndStream()
+    public function testInitializeWithMissingGroupAndStream(): void
     {
         $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogGroups')
             ->with(['logGroupNamePrefix' => $this->groupName])
             ->willReturn($logGroupsResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogGroup')
             ->with(['logGroupName' => $this->groupName]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('putRetentionPolicy')
             ->with([
@@ -293,14 +308,11 @@ class CloudWatchTest extends TestCase
 
         $logStreamResult = new Result([
             'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName . 'foo',
-                ]
-            ]
+                ['logStreamName' => $this->streamName . 'foo'],
+            ],
         ]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogStreams')
             ->with([
@@ -309,8 +321,7 @@ class CloudWatchTest extends TestCase
             ])
             ->willReturn($logStreamResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogStream')
             ->with([
@@ -318,45 +329,34 @@ class CloudWatchTest extends TestCase
                 'logStreamName' => $this->streamName,
             ]);
 
-        $handler = $this->getCUT();
-
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
+        $this->invokeInitialize($this->getCUT());
     }
 
-    public function testInitializeSkipsRetentionWhenNull()
+    public function testInitializeSkipsRetentionWhenNull(): void
     {
         $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName . 'foo']]]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogGroups')
             ->with(['logGroupNamePrefix' => $this->groupName])
             ->willReturn($logGroupsResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogGroup');
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->never())
             ->method('putRetentionPolicy');
 
         $logStreamResult = new Result([
             'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName . 'foo',
-                ]
-            ]
+                ['logStreamName' => $this->streamName . 'foo'],
+            ],
         ]);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('describeLogStreams')
             ->with([
@@ -365,107 +365,98 @@ class CloudWatchTest extends TestCase
             ])
             ->willReturn($logStreamResult);
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('createLogStream');
 
         $handler = new CloudWatch($this->clientMock, $this->groupName, $this->streamName, null);
 
-        $reflection = new \ReflectionClass($handler);
-        $reflectionMethod = $reflection->getMethod('initialize');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($handler);
+        $this->invokeInitialize($handler);
     }
 
-    public function testExceptionFromDescribeLogGroups()
+    public function testExceptionFromDescribeLogGroups(): void
     {
         // e.g. 'User is not authorized to perform logs:DescribeLogGroups'
-        /** @var CloudWatchLogsException */
+        /** @var CloudWatchLogsException&MockObject $awsException */
         $awsException = $this->getMockBuilder(CloudWatchLogsException::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         // if this fails ...
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->atLeastOnce())
             ->method('describeLogGroups')
             ->will($this->throwException($awsException));
 
         // ... this should not be called:
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->never())
             ->method('describeLogStreams');
 
         $this->expectException(CloudWatchLogsException::class);
 
         $handler = $this->getCUT(0);
-        $handler->handle($this->getRecord(Logger::INFO));
+        $handler->handle($this->getRecord(Level::Info));
     }
 
-    public function testLimitExceeded()
+    public function testLimitExceeded(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        (new CloudWatch($this->clientMock, 'a', 'b', 14, 10001));
+
+        new CloudWatch($this->clientMock, 'a', 'b', 14, 10001);
     }
 
-    public function testSendsOnClose()
+    public function testSendsOnClose(): void
     {
         $this->prepareMocks();
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
 
         $handler = $this->getCUT(1);
 
-        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Level::Debug));
 
         $handler->close();
     }
 
-    public function testFlushSendsBufferedRecords()
+    public function testFlushSendsBufferedRecords(): void
     {
         $this->prepareMocks();
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
 
         $handler = $this->getCUT(1000);
 
-        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Level::Debug));
         $handler->flush();
     }
 
-    public function testResetFlushesBuffer()
+    public function testResetFlushesBuffer(): void
     {
         $this->prepareMocks();
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
 
         $handler = $this->getCUT(1000);
 
-        $handler->handle($this->getRecord(Logger::DEBUG));
+        $handler->handle($this->getRecord(Level::Debug));
         $handler->reset();
     }
 
-    public function testSendsBatches()
+    public function testSendsBatches(): void
     {
         $this->prepareMocks();
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->exactly(2))
             ->method('putLogEvents')
             ->willReturn($this->awsResultMock);
@@ -479,7 +470,7 @@ class CloudWatchTest extends TestCase
         $handler->close();
     }
 
-    public function testFormatter()
+    public function testFormatter(): void
     {
         $handler = $this->getCUT();
 
@@ -490,47 +481,11 @@ class CloudWatchTest extends TestCase
         $this->assertEquals($expected, $formatter);
     }
 
-    private function prepareMocks()
-    {
-        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
-
-        $this
-            ->clientMock
-            ->method('describeLogGroups')
-            ->with(['logGroupNamePrefix' => $this->groupName])
-            ->willReturn($logGroupsResult);
-
-        $logStreamResult = new Result([
-            'logStreams' => [
-                [
-                    'logStreamName' => $this->streamName,
-                ]
-            ]
-        ]);
-
-        $this
-            ->clientMock
-            ->method('describeLogStreams')
-            ->with([
-                'logGroupName' => $this->groupName,
-                'logStreamNamePrefix' => $this->streamName,
-            ])
-            ->willReturn($logStreamResult);
-
-        $this->awsResultMock =
-            $this
-                ->getMockBuilder(Result::class)
-                ->onlyMethods(['get'])
-                ->disableOriginalConstructor()
-                ->getMock();
-    }
-
-    public function testSortsEntriesChronologically()
+    public function testSortsEntriesChronologically(): void
     {
         $this->prepareMocks();
 
-        $this
-            ->clientMock
+        $this->clientMock
             ->expects($this->once())
             ->method('putLogEvents')
             ->willReturnCallback(function (array $data) {
@@ -548,9 +503,8 @@ class CloudWatchTest extends TestCase
         $records = [];
 
         for ($i = 1; $i <= 4; ++$i) {
-            $record = $this->getRecord(Logger::INFO, 'record' . $i);
-            $record['datetime'] = \DateTime::createFromFormat('U', time() + $i);
-            $records[] = $record;
+            $records[] = $this->getRecord(Level::Info, 'record' . $i)
+                ->with(datetime: \DateTimeImmutable::createFromFormat('U', (string) (time() + $i)));
         }
 
         // but submitted in a different order:
@@ -562,47 +516,46 @@ class CloudWatchTest extends TestCase
         $handler->close();
     }
 
-    public function testSendsBatchesSpanning24HoursOrLess()
+    public function testSendsBatchesSpanning24HoursOrLess(): void
     {
         $this->prepareMocks();
 
-        $this
-            ->clientMock
-                ->expects($this->exactly(3))
-                ->method('putLogEvents')
-                ->willReturnCallback(function (array $data) {
-                    /** @var int|null */
-                    $earliestTime = null;
+        $this->clientMock
+            ->expects($this->exactly(3))
+            ->method('putLogEvents')
+            ->willReturnCallback(function (array $data) {
+                /** @var int|null */
+                $earliestTime = null;
 
-                    /** @var int|null */
-                    $latestTime = null;
+                /** @var int|null */
+                $latestTime = null;
 
-                    foreach ($data['logEvents'] as $logEvent) {
-                        $logTimestamp = $logEvent['timestamp'];
+                foreach ($data['logEvents'] as $logEvent) {
+                    $logTimestamp = $logEvent['timestamp'];
 
-                        if (!$earliestTime || $logTimestamp < $earliestTime) {
-                            $earliestTime = $logTimestamp;
-                        }
-
-                        if (!$latestTime || $logTimestamp > $latestTime) {
-                            $latestTime = $logTimestamp;
-                        }
+                    if (!$earliestTime || $logTimestamp < $earliestTime) {
+                        $earliestTime = $logTimestamp;
                     }
 
-                    $this->assertNotNull($earliestTime);
-                    $this->assertNotNull($latestTime);
-                    $this->assertGreaterThanOrEqual($earliestTime, $latestTime);
-                    $this->assertLessThanOrEqual(24 * 60 * 60 * 1000, $latestTime - $earliestTime);
+                    if (!$latestTime || $logTimestamp > $latestTime) {
+                        $latestTime = $logTimestamp;
+                    }
+                }
 
-                    return $this->awsResultMock;
-                });
+                $this->assertNotNull($earliestTime);
+                $this->assertNotNull($latestTime);
+                $this->assertGreaterThanOrEqual($earliestTime, $latestTime);
+                $this->assertLessThanOrEqual(24 * 60 * 60 * 1000, $latestTime - $earliestTime);
+
+                return $this->awsResultMock;
+            });
 
         $handler = $this->getCUT();
 
         // write 15 log entries spanning 3 days
         for ($i = 1; $i <= 15; ++$i) {
-            $record = $this->getRecord(Logger::INFO, 'record' . $i);
-            $record['datetime'] = \DateTime::createFromFormat('U', time() + $i * 5 * 60 * 60);
+            $record = $this->getRecord(Level::Info, 'record' . $i)
+                ->with(datetime: \DateTimeImmutable::createFromFormat('U', (string) (time() + $i * 5 * 60 * 60)));
 
             $handler->handle($record);
         }
@@ -610,41 +563,75 @@ class CloudWatchTest extends TestCase
         $handler->close();
     }
 
-    private function getCUT($batchSize = 1000)
+    private function prepareMocks(): void
+    {
+        $logGroupsResult = new Result(['logGroups' => [['logGroupName' => $this->groupName]]]);
+
+        $this->clientMock
+            ->method('describeLogGroups')
+            ->with(['logGroupNamePrefix' => $this->groupName])
+            ->willReturn($logGroupsResult);
+
+        $logStreamResult = new Result([
+            'logStreams' => [
+                ['logStreamName' => $this->streamName],
+            ],
+        ]);
+
+        $this->clientMock
+            ->method('describeLogStreams')
+            ->with([
+                'logGroupName' => $this->groupName,
+                'logStreamNamePrefix' => $this->streamName,
+            ])
+            ->willReturn($logStreamResult);
+
+        $this->awsResultMock = $this
+            ->getMockBuilder(Result::class)
+            ->onlyMethods(['get'])
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function getCUT(int $batchSize = 1000): CloudWatch
     {
         return new CloudWatch($this->clientMock, $this->groupName, $this->streamName, 14, $batchSize);
     }
 
     /**
-     * @param int $level
-     * @param string $message
-     * @param array $context
-     * @return array
+     * @param array<string, mixed> $context
      */
-    private function getRecord($level = Logger::WARNING, $message = 'test', $context = [])
-    {
-        return [
-            'message' => $message,
-            'context' => $context,
-            'level' => $level,
-            'level_name' => Logger::getLevelName($level),
-            'channel' => 'test',
-            'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
-            'extra' => [],
-        ];
+    private function getRecord(
+        Level $level = Level::Warning,
+        string $message = 'test',
+        array $context = [],
+    ): LogRecord {
+        return new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: $level,
+            message: $message,
+            context: $context,
+            extra: [],
+        );
     }
 
     /**
-     * @return array
+     * @return list<LogRecord>
      */
-    private function getMultipleRecords()
+    private function getMultipleRecords(): array
     {
         return [
-            $this->getRecord(Logger::DEBUG, 'debug message 1'),
-            $this->getRecord(Logger::DEBUG, 'debug message 2'),
-            $this->getRecord(Logger::INFO, 'information'),
-            $this->getRecord(Logger::WARNING, 'warning'),
-            $this->getRecord(Logger::ERROR, 'error'),
+            $this->getRecord(Level::Debug, 'debug message 1'),
+            $this->getRecord(Level::Debug, 'debug message 2'),
+            $this->getRecord(Level::Info, 'information'),
+            $this->getRecord(Level::Warning, 'warning'),
+            $this->getRecord(Level::Error, 'error'),
         ];
+    }
+
+    private function invokeInitialize(CloudWatch $handler): void
+    {
+        (new \ReflectionClass($handler))->getMethod('initialize')->invoke($handler);
     }
 }


### PR DESCRIPTION
v3.0.0 major release. Breaking changes — see CHANGELOG and README "Migrating from 2.x to 3.x".

- Drop PHP 7.x and 8.0; minimum is now PHP 8.1
- Drop Monolog 2; minimum is now Monolog 3 (`write()` takes `LogRecord`, `Logger::DEBUG` constants → `Level::Debug` enum)
- Constructor promotion + `readonly` for immutable state; full type coverage
- New `$createStream` argument (10th, default `true`) — set `false` to skip `DescribeLogStreams`/`CreateLogStream` for pre-provisioned streams
- Loosen `aws/aws-sdk-php` constraint from `^3.18` to `^3.0`
- Coding standard PSR-2 → PSR-12; phpstan level 8 added to CI
- PHPUnit upgraded to `^10.5 || ^11.0`
- CI matrix extended with PHP 8.1 (now 8.1 / 8.2 / 8.3 / 8.4 / 8.5)

The 9 existing constructor parameters keep their order, names, and defaults — existing Symfony positional `arguments:` lists and Laravel `with`/`handler_with` configs continue to work after upgrading PHP and Monolog.